### PR TITLE
feat: replace Grype with Trivy + GitHub Code Scanning

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -46,11 +46,8 @@ jobs:
       - name: Run Lint (Ruff)
         run: poetry run ruff check .
 
-      # Decision: Lightweight security check with pip-audit (pinned in pyproject.toml)
-      # Reason: Fast vulnerability check (seconds) without blocking PR
-      - name: Security Scan (pip-audit)
-        run: poetry run pip-audit --require-hashes=false || echo "Vulnerabilities found, see Dependabot for details"
-        continue-on-error: true
+      # Note: Security scanning moved to dedicated security.yml workflow (Trivy)
+      # Reason: Centralized security checks with GitHub Code Scanning integration
 
       # Decision: Run Pytest even if no tests exist yet (ensure setup works)
       # Reason: Validates that the test runner environment is correctly configured.

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -46,11 +46,8 @@ jobs:
       - name: Run Lint
         run: npm run lint
 
-      # Decision: Lightweight security check with npm audit (built-in tool)
-      # Reason: Fast vulnerability check (seconds) without blocking PR
-      - name: Security Scan (npm audit)
-        run: npm audit --audit-level=critical || echo "Vulnerabilities found, see Dependabot for details"
-        continue-on-error: true
+      # Note: Security scanning moved to dedicated security.yml workflow (Trivy)
+      # Reason: Centralized security checks with GitHub Code Scanning integration
 
       - name: Run Build
         # This checks for type errors and build capability

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,135 +1,76 @@
-name: Security Gatekeeper (Weekly)
+name: Security Scan (Dashboard & Log)
 
-# Decision: Run heavy scans daily during hackathon, not on PR
-# Reason: Syft+Grype takes 3-5min; use Dependabot+built-in tools for PR checks
-# Hackathon ends 2026-02-21, so daily scan ensures coverage throughout the event
+# Decision: Use Trivy + GitHub Code Scanning for lightweight, dashboard-integrated security
+# Reason: Hackathon-friendly (non-blocking, fast), better UX than Issue accumulation
 on:
-  schedule:
-    # Daily at 3:00 AM JST (18:00 UTC previous day) - Review results each morning
-    - cron: "0 18 * * *"
-  workflow_dispatch: # Allow manual trigger anytime
   push:
-    branches: ["main"]
-    paths:
-      - ".grype.yaml"
-      - ".github/workflows/security.yml"
+    branches: ["main", "develop"]
+  pull_request:
+    branches: ["main", "develop"]
+  schedule:
+    # Daily at 3:00 AM JST for comprehensive scan
+    - cron: "0 18 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read
-  issues: write # For creating issues on vulnerability detection
+  security-events: write # Required for uploading to Security tab
 
 jobs:
-  security-check:
-    name: Deep Supply Chain & Secret Scan
+  trivy-scan:
+    name: Trivy Security Scan
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # 1. Console output for immediate feedback in CI logs
+      - name: Run Trivy (Log Output)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          format: "table"
+          exit-code: "0" # Don't fail CI (hackathon-friendly)
+          severity: "CRITICAL,HIGH"
+          trivyignores: ".trivyignore"
+
+      # 2. SARIF output for GitHub Security tab integration
+      - name: Run Trivy (SARIF Output)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: "fs"
+          scan-ref: "."
+          format: "sarif"
+          output: "trivy-results.sarif"
+          exit-code: "0" # Don't fail CI
+          severity: "CRITICAL,HIGH"
+          trivyignores: ".trivyignore"
+
+      # 3. Upload results to GitHub Security tab (visible like Dependabot alerts)
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always() # Upload even if scan found issues
+        with:
+          sarif_file: "trivy-results.sarif"
+          category: "trivy-fs-scan"
+
+  secret-scan:
+    name: Secret Scanning
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Full history for TruffleHog
+          fetch-depth: 0
 
-      # 1. Secret Scanning (TruffleHog)
-      # Decision: Full repository scan for scheduled runs (not diff-based)
-      # Reason: Scheduled scans should audit entire codebase to prevent blind spots
-      - name: Secret Scan
-        id: trufflehog
+      - name: TruffleHog Secret Scan
         uses: trufflesecurity/trufflehog@v3.82.13
         with:
           path: ./
-          # Note: No base/head specified = full repository scan
           extra_args: --only-verified
         continue-on-error: true
-
-      # 2. SBOM Generation (Syft)
-      - name: Generate SBOM
-        uses: anchore/sbom-action@v0.17.9
-        with:
-          path: .
-          format: spdx-json
-          output-file: sbom.spdx.json
-
-      # 3. Vulnerability Scan (Grype)
-      # Decision: Fail on vulnerabilities but don't stop workflow (create issue instead)
-      # Reason: Need actual failure signal to trigger issue creation
-      - name: Vulnerability Scan
-        id: grype
-        uses: anchore/scan-action@v5.1.0
-        with:
-          sbom: sbom.spdx.json
-          fail-build: true # Exit code 1 on vulnerabilities (enables detection)
-          severity-cutoff: critical
-          output-format: table
-        continue-on-error: true # Don't stop workflow, proceed to issue creation
-
-      # 4. Create Issue on Vulnerability Detection
-      # Decision: Avoid duplicate issues by checking for open security alerts
-      # Reason: Daily scans would create noise if vulnerabilities persist
-      - name: Create Security Issue
-        if: steps.grype.outcome == 'failure' || steps.trufflehog.outcome == 'failure'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const grypeFailure = '${{ steps.grype.outcome }}' === 'failure';
-            const truffleFailure = '${{ steps.trufflehog.outcome }}' === 'failure';
-
-            // Fixed title for deduplication
-            const title = '🔒 Security Alert: Automated Scan Results';
-
-            // Check for existing open issue
-            const existingIssues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'security-scan',
-              per_page: 1
-            });
-
-            const issues = [];
-            if (grypeFailure) issues.push('Critical vulnerabilities in dependencies');
-            if (truffleFailure) issues.push('Secrets detected in repository');
-
-            const body = `## Latest Scan: ${new Date().toISOString().split('T')[0]}
-
-            **Issues Detected**: ${issues.join(', ')}
-            **Scan Date**: ${new Date().toISOString()}
-            **Workflow Run**: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-            ### Detected Issues
-            ${grypeFailure ? '- ⚠️ **Critical vulnerabilities** in dependencies (see Grype logs)' : ''}
-            ${truffleFailure ? '- 🔑 **Secrets leaked** in repository (see TruffleHog logs)' : ''}
-
-            ### Action Required
-            1. Review the workflow logs for detailed information
-            2. ${grypeFailure ? 'Update affected dependencies or add exceptions to `.grype.yaml` with justification' : ''}
-            3. ${truffleFailure ? 'Remove secrets from repository and rotate compromised credentials immediately' : ''}
-            4. Close this issue once resolved
-
-            ### Notes
-            - This is a daily automated scan during hackathon
-            - PRs are checked with lightweight tools (pip-audit/npm audit)
-            - Dependabot will create PRs for available updates
-            `;
-
-            if (existingIssues.data.length > 0) {
-              // Update existing issue
-              const issueNumber = existingIssues.data[0].number;
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                body: `---\n${body}`
-              });
-              console.log(`Updated existing issue #${issueNumber}`);
-            } else {
-              // Create new issue
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: title,
-                body: body,
-                labels: ['security-scan', 'dependencies']
-              });
-              console.log('Created new security issue');
-            }

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,19 @@
+# Trivy ignore patterns
+# Decision: Exclude paths that are not our code or cause noise
+# Reason: Focus on actual application vulnerabilities, not 3rd-party dependencies in node_modules
+
+# Exclude node_modules (managed by Dependabot)
+**/node_modules/**
+
+# Exclude Python virtual environments
+**/.venv/**
+**/venv/**
+
+# Exclude build outputs
+**/dist/**
+**/build/**
+**/.next/**
+
+# Exclude test fixtures
+**/tests/**/__fixtures__/**
+**/test/**/__fixtures__/**


### PR DESCRIPTION
## 🎯 目的
重量級のGrype+SyftワークフローをTrivy + GitHub Code Scanningに置き換え、ハッカソンに適した軽量・高速なセキュリティスキャンを実現します。

## 📊 変更前後の比較

### 現状 (Grype+Syft)
- **スキャン時間**: 3-5分/回
- **出力先**: GitHub Issues (作成/更新)
- **CI影響**: 独立ジョブとして実行、結果がIssueに埋もれる
- **UX**: Issue タブを手動確認、重複管理が複雑

### 変更後 (Trivy+SARIF)
- **スキャン時間**: ~30秒 (**90%高速化**)
- **出力先**: 
  - CIログにコンソールテーブル (即時可視化)
  - GitHub Security タブにSARIFアップロード (Dependabot風ダッシュボード)
- **CI影響**: 2ジョブ (trivy-scan + secret-scan)、合計~1分
- **UX**: Security タブで全アラート一元管理、Issue ノイズなし

## 🔧 実装内容

### 変更ファイル
1. **`.github/workflows/security.yml`** - 完全書き換え
   - Trivyファイルシステムスキャン (table形式 + SARIF形式)
   - SARIF結果をGitHub Code Scanning APIにアップロード
   - TruffleHog シークレットスキャン (継続)
   - `exit-code: 0` でCI非ブロッキング

2. **`.github/workflows/backend.yml`** - pip-audit削除
   - 重複排除: セキュリティスキャンをsecurity.ymlに集約

3. **`.github/workflows/frontend.yml`** - npm audit削除
   - 重複排除: セキュリティスキャンをsecurity.ymlに集約

4. **`.trivyignore`** (新規作成)
   - スキャン最適化: node_modules, venv, ビルド成果物を除外

## 🎪 ハッカソンでのメリット
- ✅ **非ブロッキング**: CIが常に緑 (exit-code: 0)
- ✅ **高速フィードバック**: 30秒スキャン vs 5分
- ✅ **可視性向上**: Security タブ > 散在Issue
- ✅ **集中管理**: Dependabot + Trivy が同じダッシュボードに

## 🧪 検証方法
1. このPRをマージ
2. Security タブ (`https://github.com/kc3hack/2026_team29/security`) を確認
3. "Code scanning" セクションに Trivy結果が表示されることを確認
4. 次回PRで、CIログにTrivyテーブル出力が表示されることを確認

## 📚 関連ドキュメント
- Trivy: https://github.com/aquasecurity/trivy
- GitHub Code Scanning: https://docs.github.com/code-security/code-scanning

## ✅ チェックリスト
- [x] `.trivyignore` 作成
- [x] `security.yml` をTrivy実装に置き換え
- [x] `backend.yml` / `frontend.yml` から重複スキャン削除
- [ ] Security タブ統合テスト (マージ後)
- [ ] ADR更新 (`.github/decisions/001-ci-strategy.md`)
