### PR TITLE
feat: スキルツリーのレイアウト・UI改善

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, DotGothic16 } from "next/font/google";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -10,6 +10,12 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+});
+
+const dotGothic = DotGothic16({
+  weight: "400",
+  subsets: ["latin"],
+  variable: "--font-dot-gothic",
 });
 
 export const metadata: Metadata = {
@@ -25,7 +31,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${dotGothic.variable} antialiased`}
       >
         {children}
       </body>

--- a/frontend/src/app/skills/layout.tsx
+++ b/frontend/src/app/skills/layout.tsx
@@ -1,0 +1,42 @@
+import { DotGothic16 } from "next/font/google";
+import { AppSidebar } from "../../features/dashboard/components/AppSidebar";
+
+const dotGothic = DotGothic16({
+  weight: "400",
+  subsets: ["latin"],
+  variable: "--font-dot-gothic",
+});
+
+export const metadata = {
+  title: 'Skill Tree',
+  description: 'Interactive RPG-style skill tree',
+};
+
+export default function Layout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`${dotGothic.variable} font-sans min-h-screen bg-[#FDFEF0]`}>
+      {/* Top Header Bar - Full Width */}
+      <header className="sticky top-0 z-50 flex h-16 w-full items-center justify-end bg-[#559C71] px-6 text-white shadow-md">
+         <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-gray-600 shadow-sm cursor-pointer hover:bg-gray-100 transition-colors">
+            {/* User Icon Placeholder */}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-6 h-6 text-gray-400">
+              <path fillRule="evenodd" d="M7.5 6a4.5 4.5 0 119 0 4.5 4.5 0 01-9 0zM3.751 20.105a8.25 8.25 0 0116.498 0 .75.75 0 01-.437.695A18.683 18.683 0 0112 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 01-.437-.695z" clipRule="evenodd" />
+            </svg>
+         </div>
+      </header>
+
+      <div className="flex">
+         <AppSidebar />
+         
+         {/* Main Content Area */}
+         <div className="flex-1 min-h-[calc(100vh-4rem)] sm:ml-64 relative">
+            {children}
+         </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/skills/page.tsx
+++ b/frontend/src/app/skills/page.tsx
@@ -1,28 +1,30 @@
-"use client"
+"use client";
 
-import { useState, useCallback, useEffect } from "react"
-import { SkillTreeCanvas } from "../../features/skill-tree/components/SkillTreeCanvas"
-import { SkillNodePanel } from "../../features/skill-tree/components/SkillNodePanel"
-import { RankBar } from "../../features/skill-tree/components/RankBar"
-import { SkillLegend } from "../../features/skill-tree/components/SkillLegend"
-import { ZoomControls } from "../../features/skill-tree/components/ZoomControls"
-import type { SkillNode } from "../../features/skill-tree/types/data"
+import { useState, useCallback } from "react";
+import { SkillTreeCanvas } from "../../features/skill-tree/components/SkillTreeCanvas";
+import { SkillNodePanel } from "../../features/skill-tree/components/SkillNodePanel";
+import { RankBar } from "../../features/skill-tree/components/RankBar";
+import { SkillLegend } from "../../features/skill-tree/components/SkillLegend";
+import { ZoomControls } from "../../features/skill-tree/components/ZoomControls";
+import type { SkillNode } from "../../features/skill-tree/types/data";
 
 export default function SkillTreePage() {
-  const [selectedNode, setSelectedNode] = useState<SkillNode | null>(null)
-  const [zoomAction, setZoomAction] = useState<{ type: string; ts: number } | null>(null)
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
+  const [selectedNode, setSelectedNode] = useState<SkillNode | null>(null);
+  const [zoomAction, setZoomAction] = useState<{
+    type: string;
+    ts: number;
+  } | null>(null);
+  const [mounted] = useState(true);
 
   const handleSelectNode = useCallback((node: SkillNode | null) => {
-    setSelectedNode(node)
-  }, [])
+    setSelectedNode(node);
+  }, []);
 
   return (
-    <div className="relative w-full h-[calc(100vh-4rem)] overflow-hidden rounded-lg border border-border" style={{ background: "#0a0f08" }}>
+    <div
+      className="relative w-full h-[calc(100vh-4rem)] overflow-hidden rounded-lg border border-border"
+      style={{ background: "#0a0f08" }}
+    >
       <SkillTreeCanvas
         onSelectNode={handleSelectNode}
         selectedNode={selectedNode}
@@ -49,15 +51,24 @@ export default function SkillTreePage() {
           {"SKILL TREE"}
         </h1>
         {mounted && (
-          <p className="text-[9px] mt-1" style={{ color: "#666680" }} suppressHydrationWarning>
-            {"\u30C9\u30E9\u30C3\u30B0\u3067\u79FB\u52D5 / \u30B9\u30AF\u30ED\u30FC\u30EB\u3067\u30BA\u30FC\u30E0 / \u30CE\u30FC\u30C9\u3092\u30AF\u30EA\u30C3\u30AF\u3067\u8A73\u7D30"}
+          <p
+            className="text-[9px] mt-1"
+            style={{ color: "#666680" }}
+            suppressHydrationWarning
+          >
+            {
+              "\u30C9\u30E9\u30C3\u30B0\u3067\u79FB\u52D5 / \u30B9\u30AF\u30ED\u30FC\u30EB\u3067\u30BA\u30FC\u30E0 / \u30CE\u30FC\u30C9\u3092\u30AF\u30EA\u30C3\u30AF\u3067\u8A73\u7D30"
+            }
           </p>
         )}
       </div>
 
       {selectedNode && (
-        <SkillNodePanel node={selectedNode} onClose={() => setSelectedNode(null)} />
+        <SkillNodePanel
+          node={selectedNode}
+          onClose={() => setSelectedNode(null)}
+        />
       )}
     </div>
-  )
+  );
 }

--- a/frontend/src/app/skills/page.tsx
+++ b/frontend/src/app/skills/page.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { useState, useCallback, useEffect } from "react"
+import { SkillTreeCanvas } from "../../features/skill-tree/components/SkillTreeCanvas"
+import { SkillNodePanel } from "../../features/skill-tree/components/SkillNodePanel"
+import { RankBar } from "../../features/skill-tree/components/RankBar"
+import { SkillLegend } from "../../features/skill-tree/components/SkillLegend"
+import { ZoomControls } from "../../features/skill-tree/components/ZoomControls"
+import type { SkillNode } from "../../features/skill-tree/types/data"
+
+export default function SkillTreePage() {
+  const [selectedNode, setSelectedNode] = useState<SkillNode | null>(null)
+  const [zoomAction, setZoomAction] = useState<{ type: string; ts: number } | null>(null)
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const handleSelectNode = useCallback((node: SkillNode | null) => {
+    setSelectedNode(node)
+  }, [])
+
+  return (
+    <div className="relative w-full h-[calc(100vh-4rem)] overflow-hidden rounded-lg border border-border" style={{ background: "#0a0f08" }}>
+      <SkillTreeCanvas
+        onSelectNode={handleSelectNode}
+        selectedNode={selectedNode}
+        zoomAction={zoomAction}
+      />
+
+      <RankBar />
+      <SkillLegend />
+      <ZoomControls
+        onZoomIn={() => setZoomAction({ type: "in", ts: Date.now() })}
+        onZoomOut={() => setZoomAction({ type: "out", ts: Date.now() })}
+        onReset={() => setZoomAction({ type: "reset", ts: Date.now() })}
+      />
+
+      {/* Title */}
+      <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20 text-center pointer-events-none font-sans">
+        <h1
+          className="text-base font-bold tracking-widest"
+          style={{
+            color: "#e8b849",
+            textShadow: "2px 2px 0 #7a5a10, -1px -1px 0 #0a0a0a",
+          }}
+        >
+          {"SKILL TREE"}
+        </h1>
+        {mounted && (
+          <p className="text-[9px] mt-1" style={{ color: "#666680" }} suppressHydrationWarning>
+            {"\u30C9\u30E9\u30C3\u30B0\u3067\u79FB\u52D5 / \u30B9\u30AF\u30ED\u30FC\u30EB\u3067\u30BA\u30FC\u30E0 / \u30CE\u30FC\u30C9\u3092\u30AF\u30EA\u30C3\u30AF\u3067\u8A73\u7D30"}
+          </p>
+        )}
+      </div>
+
+      {selectedNode && (
+        <SkillNodePanel node={selectedNode} onClose={() => setSelectedNode(null)} />
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/dashboard/components/DashboardContainer.tsx
+++ b/frontend/src/features/dashboard/components/DashboardContainer.tsx
@@ -128,7 +128,7 @@ export function DashboardContainer({ userId = 'default-user' }: DashboardContain
               </h3>
               {mounted && (
                 <p className="text-[10px] mt-1" style={{ color: "#666680" }} suppressHydrationWarning>
-                  ドラッグで移動 / スクロールでズーム / クリックで詳細
+                  スクロールでズーム / クリックで詳細
                 </p>
               )}
             </div>

--- a/frontend/src/features/dashboard/components/DashboardContainer.tsx
+++ b/frontend/src/features/dashboard/components/DashboardContainer.tsx
@@ -118,7 +118,7 @@ export function DashboardContainer({ userId = 'default-user' }: DashboardContain
             {/* Title Overlay */}
             <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20 text-center pointer-events-none font-sans">
               <h3
-                className="text-base font-bold tracking-widest"
+                className="text-2xl font-bold tracking-widest"
                 style={{
                   color: "#e8b849",
                   textShadow: "2px 2px 0 #7a5a10, -1px -1px 0 #0a0a0a",

--- a/frontend/src/features/dashboard/components/DashboardContainer.tsx
+++ b/frontend/src/features/dashboard/components/DashboardContainer.tsx
@@ -5,11 +5,16 @@
  * ダッシュボードの全コンポーネントを統合し、データフェッチを担当
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import type { UserStatus } from '../types';
 import { fetchUserDashboard } from '../api/mock';
 import { AcquiredBadges } from './AcquiredBadges';
-import { SkillRoadmap } from './SkillRoadmap';
+import { SkillTreeCanvas } from '../../skill-tree/components/SkillTreeCanvas';
+import { SkillNodePanel } from '../../skill-tree/components/SkillNodePanel';
+import { RankBar } from '../../skill-tree/components/RankBar';
+import { SkillLegend } from '../../skill-tree/components/SkillLegend';
+import { ZoomControls } from '../../skill-tree/components/ZoomControls';
+import type { SkillNode as TreeSkillNode } from '../../skill-tree/types/data';
 
 interface DashboardContainerProps {
   userId?: string;
@@ -19,6 +24,19 @@ export function DashboardContainer({ userId = 'default-user' }: DashboardContain
   const [userStatus, setUserStatus] = useState<UserStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  // Skill Tree States
+  const [selectedNode, setSelectedNode] = useState<TreeSkillNode | null>(null);
+  const [zoomAction, setZoomAction] = useState<{ type: string; ts: number } | null>(null);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const handleSelectNode = useCallback((node: TreeSkillNode | null) => {
+    setSelectedNode(node);
+  }, []);
 
   useEffect(() => {
     const loadDashboard = async () => {
@@ -68,7 +86,7 @@ export function DashboardContainer({ userId = 'default-user' }: DashboardContain
     <main className="min-h-screen bg-[#FDFEF0] px-4 py-8">
       <div className="mx-auto max-w-5xl space-y-12">
         {/* Header Section */}
-        <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 relative z-10">
             <h1 className="text-4xl font-bold tracking-tight text-[#2C5F2D]">こんにちは</h1>
             
             {/* Continue Button aligned right */}
@@ -82,12 +100,49 @@ export function DashboardContainer({ userId = 'default-user' }: DashboardContain
         </div>
 
         {/* Skill Tree Section */}
-        <div className="flex justify-center py-8">
-            <SkillRoadmap skills={userStatus.skillRoadmap} />
-        </div>
+        <section className="relative z-0">
+          <div className="relative w-full h-[600px] overflow-hidden rounded-xl border-4 border-[#2C5F2D] bg-[#0a0f08] shadow-lg">
+            <SkillTreeCanvas
+              onSelectNode={handleSelectNode}
+              selectedNode={selectedNode}
+              zoomAction={zoomAction}
+            />
+            <RankBar />
+            <SkillLegend />
+            <ZoomControls
+              onZoomIn={() => setZoomAction({ type: "in", ts: Date.now() })}
+              onZoomOut={() => setZoomAction({ type: "out", ts: Date.now() })}
+              onReset={() => setZoomAction({ type: "reset", ts: Date.now() })}
+            />
+            
+            {/* Title Overlay */}
+            <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20 text-center pointer-events-none font-sans">
+              <h3
+                className="text-base font-bold tracking-widest"
+                style={{
+                  color: "#e8b849",
+                  textShadow: "2px 2px 0 #7a5a10, -1px -1px 0 #0a0a0a",
+                }}
+              >
+                SKILL TREE
+              </h3>
+              {mounted && (
+                <p className="text-[10px] mt-1" style={{ color: "#666680" }} suppressHydrationWarning>
+                  ドラッグで移動 / スクロールでズーム / クリックで詳細
+                </p>
+              )}
+            </div>
+
+            {selectedNode && (
+              <SkillNodePanel node={selectedNode} onClose={() => setSelectedNode(null)} />
+            )}
+          </div>
+        </section>
 
         {/* Acquired Badges Section */}
-        <AcquiredBadges />
+        <section className="relative z-10 w-full">
+          <AcquiredBadges />
+        </section>
       </div>
     </main>
   );

--- a/frontend/src/features/grades/components/BadgeList.tsx
+++ b/frontend/src/features/grades/components/BadgeList.tsx
@@ -1,13 +1,13 @@
-'use client';
+"use client";
 
-import React from 'react';
-import { Badge } from '../types';
+import React from "react";
+import { Badge } from "../types";
 
 interface BadgeListProps {
   badges: Badge[];
 }
 
-export const BadgeList: React.FC<BadgeListProps> = ({ badges }) => {
+export const BadgeList: React.FC<BadgeListProps> = () => {
   return (
     <div className="w-full max-w-5xl mx-auto px-4">
       <div className="flex items-center gap-4 mb-4 pl-2">
@@ -19,43 +19,52 @@ export const BadgeList: React.FC<BadgeListProps> = ({ badges }) => {
             <option>実技</option>
           </select>
           <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
-            <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-              <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/>
+            <svg
+              className="fill-current h-4 w-4"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+            >
+              <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" />
             </svg>
           </div>
         </div>
       </div>
-      
+
       <div className="border-2 border-[#1a4023] rounded-[40px] bg-[#f8fff8] p-8 lg:p-12 min-h-[250px] lg:min-h-[300px] flex items-center justify-around relative overflow-hidden">
         {/* Large Trophy on the left */}
         <div className="flex flex-col items-center justify-center transform scale-125 lg:scale-150">
-          <span className="text-[100px] lg:text-[120px] drop-shadow-lg filter">🏆</span>
+          <span className="text-[100px] lg:text-[120px] drop-shadow-lg filter">
+            🏆
+          </span>
         </div>
 
         {/* Medals on the right */}
         <div className="flex gap-8 lg:gap-12 items-end">
           {/* Gold - 1st */}
           <div className="flex flex-col items-center">
-             <div className="relative">
-               <span className="text-[60px] lg:text-[80px] drop-shadow-md">🥇</span>
-               
-             </div>
+            <div className="relative">
+              <span className="text-[60px] lg:text-[80px] drop-shadow-md">
+                🥇
+              </span>
+            </div>
           </div>
-          
+
           {/* Silver - 2nd */}
           <div className="flex flex-col items-center">
-             <div className="relative">
-               <span className="text-[60px] lg:text-[80px] drop-shadow-md">🥈</span>
-               
-             </div>
+            <div className="relative">
+              <span className="text-[60px] lg:text-[80px] drop-shadow-md">
+                🥈
+              </span>
+            </div>
           </div>
-          
+
           {/* Bronze - 3rd */}
           <div className="flex flex-col items-center">
-             <div className="relative">
-               <span className="text-[60px] lg:text-[80px] drop-shadow-md">🥉</span>
-               
-             </div>
+            <div className="relative">
+              <span className="text-[60px] lg:text-[80px] drop-shadow-md">
+                🥉
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/features/skill-tree/components/RankBar.tsx
+++ b/frontend/src/features/skill-tree/components/RankBar.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { RANKS, SKILL_NODES } from "../types/data"
+
+export function RankBar() {
+  const completedCount = SKILL_NODES.filter((n) => n.status === "completed").length
+  const totalCount = SKILL_NODES.length
+  const progress = completedCount / totalCount
+  const tierIndex = Math.min(Math.floor(progress * 10), 9)
+  const currentRank = RANKS[tierIndex]
+
+  const levelColors: Record<string, { text: string; bar: string; barDark: string }> = {
+    beginner: { text: "#5abf5a", bar: "#5abf5a", barDark: "#2e8a2e" },
+    intermediate: { text: "#e8b849", bar: "#e8b849", barDark: "#a67c20" },
+    master: { text: "#cc66dd", bar: "#cc66dd", barDark: "#8833aa" },
+  }
+  const colors = levelColors[currentRank.level]
+
+  return (
+    <div
+      className="absolute top-3 left-3 z-20 flex items-center gap-2 px-2.5 py-1.5 font-sans"
+      style={{
+        background: "rgba(10,10,20,0.75)",
+        border: "2px solid rgba(232,184,73,0.5)",
+        backdropFilter: "blur(4px)",
+      }}
+    >
+      {/* Tier badge */}
+      <div
+        className="w-6 h-6 flex items-center justify-center text-[10px] font-bold shrink-0"
+        style={{
+          background: "rgba(42,42,78,0.8)",
+          border: "2px solid",
+          borderColor: colors.text,
+          color: colors.text,
+        }}
+      >
+        {currentRank.tier}
+      </div>
+
+      <div className="flex flex-col gap-0.5">
+        <div className="flex items-center gap-1.5">
+          <span className="text-[10px] font-bold" style={{ color: colors.text }}>
+            {currentRank.nameJa}
+          </span>
+          <span className="text-[8px]" style={{ color: "#666680" }}>
+            {currentRank.nameEn}
+          </span>
+        </div>
+
+        {/* Tiny EXP bar */}
+        <div className="flex items-center gap-1.5">
+          <span className="text-[7px]" style={{ color: "#666680" }}>{"EXP"}</span>
+          <div
+            className="h-[6px] w-20 relative overflow-hidden"
+            style={{
+              background: "#0a0a1e",
+              border: "1px solid #333355",
+            }}
+          >
+            <div
+              className="h-full absolute left-0 top-0"
+              style={{
+                width: `${progress * 100}%`,
+                background: colors.bar,
+                boxShadow: `inset 0 -1px 0 ${colors.barDark}`,
+              }}
+            />
+          </div>
+          <span className="text-[7px]" style={{ color: "#666680" }}>
+            {completedCount}/{totalCount}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/skill-tree/components/SkillLegend.tsx
+++ b/frontend/src/features/skill-tree/components/SkillLegend.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+const rpgBoxStyle = {
+  background: "#1a1a2e",
+  border: "4px solid #e8b849",
+  boxShadow: "inset 2px 2px 0 #f5d97a, inset -2px -2px 0 #a67c20, 0 4px 0 #0a0a1a",
+  imageRendering: "pixelated" as const,
+}
+
+const statusEntries = [
+  { color: "#e8b849", label: "\u30AF\u30EA\u30A2\u6E08\u307F" },
+  { color: "#5abf5a", label: "\u6311\u6226\u53EF\u80FD" },
+  { color: "#5a6068", label: "\u30ED\u30C3\u30AF\u4E2D" },
+]
+
+const categoryEntries = [
+  { color: "#55aaff", label: "Web/App" },
+  { color: "#e8b849", label: "AI" },
+  { color: "#e85555", label: "Security" },
+  { color: "#55cc55", label: "Infra" },
+  { color: "#cc66dd", label: "Design" },
+]
+
+export function SkillLegend() {
+  return (
+    <div className="absolute top-4 right-4 z-20 p-3 font-sans" style={rpgBoxStyle}>
+      <div className="text-[9px] font-bold mb-2 uppercase tracking-widest" style={{ color: "#8888aa" }}>
+        {"STATUS"}
+      </div>
+      <div className="flex flex-col gap-1.5 mb-3">
+        {statusEntries.map((e, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <div
+              className="w-3 h-3 shrink-0"
+              style={{ background: e.color, border: "1px solid #000", boxShadow: `inset 1px 1px 0 ${e.color}88` }}
+            />
+            <span className="text-[10px]" style={{ color: "#c0c0d0" }}>{e.label}</span>
+          </div>
+        ))}
+      </div>
+
+      <div className="text-[9px] font-bold mb-2 uppercase tracking-widest" style={{ color: "#8888aa" }}>
+        {"CATEGORY"}
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {categoryEntries.map((c, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <div
+              className="w-3 h-3 shrink-0"
+              style={{ background: c.color, border: "1px solid #000", boxShadow: `inset 1px 1px 0 ${c.color}88` }}
+            />
+            <span className="text-[10px]" style={{ color: "#c0c0d0" }}>{c.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/skill-tree/components/SkillNodePanel.tsx
+++ b/frontend/src/features/skill-tree/components/SkillNodePanel.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { RANKS, type SkillNode } from "../types/data"
+
+interface Props {
+  node: SkillNode
+  onClose: () => void
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  completed: "\u30AF\u30EA\u30A2\u6E08\u307F",
+  available: "\u6311\u6226\u53EF\u80FD",
+  locked: "\u30ED\u30C3\u30AF\u4E2D",
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  completed: "#e8b849",
+  available: "#5abf5a",
+  locked: "#5a6068",
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  web: "Web / App",
+  ai: "AI",
+  security: "Security",
+  infra: "Infrastructure",
+  design: "Design",
+}
+
+const CAT_COLORS: Record<string, string> = {
+  web: "#55aaff",
+  ai: "#e8b849",
+  security: "#e85555",
+  infra: "#55cc55",
+  design: "#cc66dd",
+}
+
+export function SkillNodePanel({ node, onClose }: Props) {
+  const rank = RANKS.find((r) => r.tier === node.tier) || RANKS[0]
+  const catColor = CAT_COLORS[node.category]
+  const statusColor = STATUS_COLORS[node.status]
+
+  return (
+    <div
+      className="absolute bottom-6 left-1/2 -translate-x-1/2 z-30 w-[360px] max-w-[calc(100vw-2rem)] p-4 font-sans animate-in slide-in-from-bottom-4 duration-200"
+      style={{
+        background: "#1a1a2e",
+        border: "4px solid #e8b849",
+        boxShadow: "inset 2px 2px 0 #f5d97a, inset -2px -2px 0 #a67c20, 0 4px 0 #0a0a1a",
+        imageRendering: "pixelated",
+      }}
+    >
+      {/* Close button */}
+      <button
+        onClick={onClose}
+        className="absolute top-2 right-3 text-sm font-bold"
+        style={{ color: "#8888aa" }}
+        aria-label="Close panel"
+      >
+        {"x"}
+      </button>
+
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-3">
+        {/* Pixel icon box */}
+        <div
+          className="w-10 h-10 flex items-center justify-center text-lg shrink-0"
+          style={{
+            background: "#2a2a4e",
+            border: `3px solid ${statusColor}`,
+            boxShadow: `inset 1px 1px 0 ${statusColor}66`,
+            color: statusColor,
+          }}
+        >
+          {node.status === "completed" ? "\u2713" : node.status === "available" ? "!" : "\u25A0"}
+        </div>
+        <div>
+          <h3 className="text-sm font-bold leading-tight" style={{ color: statusColor }}>
+            {node.label}
+          </h3>
+          {/* <p className="text-[9px]" style={{ color: "#8888aa" }}>
+            {node.labelEn}
+          </p> */}
+        </div>
+      </div>
+
+      {/* Tags row */}
+      <div className="flex flex-wrap gap-1.5 mb-3">
+        <span
+          className="text-[9px] px-2 py-0.5"
+          style={{ background: `${catColor}22`, color: catColor, border: `2px solid ${catColor}44` }}
+        >
+          {CATEGORY_LABELS[node.category]}
+        </span>
+        <span
+          className="text-[9px] px-2 py-0.5"
+          style={{ background: `${statusColor}22`, color: statusColor, border: `2px solid ${statusColor}44` }}
+        >
+          {STATUS_LABELS[node.status]}
+        </span>
+        <span
+          className="text-[9px] px-2 py-0.5"
+          style={{ background: "#2a2a4e", color: "#8888aa", border: "2px solid #444466" }}
+        >
+          {"Tier " + node.tier + " " + rank.nameJa}
+        </span>
+      </div>
+
+      {/* Description */}
+      <p className="text-xs leading-relaxed" style={{ color: "#c0c0d0" }}>
+        {node.description}
+      </p>
+
+      {/* Action hint */}
+      {node.status === "available" && (
+        <div
+          className="mt-3 text-[10px] text-center py-1.5"
+          style={{ background: "#1a2a1a", border: "2px solid #5abf5a44", color: "#5abf5a" }}
+        >
+          {"GitHub\u30EA\u30DD\u30B8\u30C8\u30EA\u3092\u5206\u6790\u3057\u3066\u30B9\u30AD\u30EB\u3092\u81EA\u52D5\u5224\u5B9A\u3057\u307E\u3059"}
+        </div>
+      )}
+      {node.status === "locked" && (
+        <div
+          className="mt-3 text-[10px] text-center py-1.5"
+          style={{ background: "#1a1a2a", border: "2px solid #44446644", color: "#8888aa" }}
+        >
+          {"\u524D\u63D0\u30B9\u30AD\u30EB\u3092\u30AF\u30EA\u30A2\u3059\u308B\u3068\u30A2\u30F3\u30ED\u30C3\u30AF\u3055\u308C\u307E\u3059"}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/skill-tree/components/SkillTreeCanvas.tsx
+++ b/frontend/src/features/skill-tree/components/SkillTreeCanvas.tsx
@@ -410,18 +410,11 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
     const c = canvasRef.current
     if (!c) return
 
-    const onMD = (e: MouseEvent) => { drag.current = { on: true, sx: e.clientX, sy: e.clientY, lx: e.clientX, ly: e.clientY } }
-    const onMM = (e: MouseEvent) => {
-      if (!drag.current.on) return
-      const dpr = window.devicePixelRatio
-      tf.current.x += (e.clientX - drag.current.lx) * dpr
-      tf.current.y += (e.clientY - drag.current.ly) * dpr
-      drag.current.lx = e.clientX; drag.current.ly = e.clientY
-    }
+    const onMD = (e: MouseEvent) => { drag.current = { on: false, sx: e.clientX, sy: e.clientY, lx: e.clientX, ly: e.clientY } }
+    const onMM = (_e: MouseEvent) => { /* drag disabled */ }
     const onMU = (e: MouseEvent) => {
       const d = drag.current
       const moved = Math.abs(e.clientX - d.sx) > 5 || Math.abs(e.clientY - d.sy) > 5
-      d.on = false
       if (!moved) {
         const rect = c.getBoundingClientRect()
         const sx = (e.clientX - rect.left) * window.devicePixelRatio
@@ -440,7 +433,7 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
 
     let lastDist = 0
     const onTS = (e: TouchEvent) => {
-      if (e.touches.length === 1) drag.current = { on: true, sx: e.touches[0].clientX, sy: e.touches[0].clientY, lx: e.touches[0].clientX, ly: e.touches[0].clientY }
+      if (e.touches.length === 1) drag.current = { on: false, sx: e.touches[0].clientX, sy: e.touches[0].clientY, lx: e.touches[0].clientX, ly: e.touches[0].clientY }
       else if (e.touches.length === 2) {
         const dx = e.touches[0].clientX - e.touches[1].clientX
         const dy = e.touches[0].clientY - e.touches[1].clientY
@@ -449,12 +442,7 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
     }
     const onTM = (e: TouchEvent) => {
       e.preventDefault()
-      if (e.touches.length === 1 && drag.current.on) {
-        const dpr = window.devicePixelRatio
-        tf.current.x += (e.touches[0].clientX - drag.current.lx) * dpr
-        tf.current.y += (e.touches[0].clientY - drag.current.ly) * dpr
-        drag.current.lx = e.touches[0].clientX; drag.current.ly = e.touches[0].clientY
-      } else if (e.touches.length === 2) {
+      if (e.touches.length === 2) { /* 1-finger pan disabled */
         const dx = e.touches[0].clientX - e.touches[1].clientX
         const dy = e.touches[0].clientY - e.touches[1].clientY
         const dist = Math.sqrt(dx * dx + dy * dy)
@@ -497,7 +485,7 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
 
   return (
     <div ref={boxRef} className="absolute inset-0">
-      <canvas ref={canvasRef} className="block w-full h-full cursor-grab active:cursor-grabbing" style={{ imageRendering: "pixelated" }} />
+      <canvas ref={canvasRef} className="block w-full h-full cursor-default" style={{ imageRendering: "pixelated" }} />
     </div>
   )
 }

--- a/frontend/src/features/skill-tree/components/SkillTreeCanvas.tsx
+++ b/frontend/src/features/skill-tree/components/SkillTreeCanvas.tsx
@@ -329,7 +329,7 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
       // Label
       ctx.save()
       // Use fallback if DotGothic16 is not loaded.
-      ctx.font = "bold 13px 'DotGothic16', monospace"
+      ctx.font = "bold 17px 'DotGothic16', monospace"
       ctx.textAlign = "center"
       ctx.textBaseline = "top"
       // shadow

--- a/frontend/src/features/skill-tree/components/SkillTreeCanvas.tsx
+++ b/frontend/src/features/skill-tree/components/SkillTreeCanvas.tsx
@@ -287,9 +287,9 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
         ctx.fillRect(Math.round((x - PX) / PX) * PX, Math.round((ay + PX * 6) / PX) * PX, PX * 2, PX)
       }
 
-      // Category color outer ring (4px)
+      // Category color outer ring (3px)
       const cc = status === "locked" ? "#2a2e34" : CAT[category]
-      px(ctx, x - S - PX * 4, y - S - PX * 4, (S + PX * 4) * 2, (S + PX * 4) * 2, cc)
+      px(ctx, x - S - PX * 3, y - S - PX * 3, (S + PX * 3) * 2, (S + PX * 3) * 2, cc)
 
       // Outline
       px(ctx, x - S - PX, y - S - PX, (S + PX) * 2, (S + PX) * 2, p.rim)
@@ -329,7 +329,7 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
       // Label
       ctx.save()
       // Use fallback if DotGothic16 is not loaded.
-      ctx.font = "bold 17px 'DotGothic16', monospace"
+      ctx.font = "bold 21px 'DotGothic16', monospace"
       ctx.textAlign = "center"
       ctx.textBaseline = "top"
       // shadow

--- a/frontend/src/features/skill-tree/components/SkillTreeCanvas.tsx
+++ b/frontend/src/features/skill-tree/components/SkillTreeCanvas.tsx
@@ -287,9 +287,9 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
         ctx.fillRect(Math.round((x - PX) / PX) * PX, Math.round((ay + PX * 6) / PX) * PX, PX * 2, PX)
       }
 
-      // Category color outer ring (2px)
+      // Category color outer ring (4px)
       const cc = status === "locked" ? "#2a2e34" : CAT[category]
-      px(ctx, x - S - PX * 2, y - S - PX * 2, (S + PX * 2) * 2, (S + PX * 2) * 2, cc)
+      px(ctx, x - S - PX * 4, y - S - PX * 4, (S + PX * 4) * 2, (S + PX * 4) * 2, cc)
 
       // Outline
       px(ctx, x - S - PX, y - S - PX, (S + PX) * 2, (S + PX) * 2, p.rim)

--- a/frontend/src/features/skill-tree/components/SkillTreeCanvas.tsx
+++ b/frontend/src/features/skill-tree/components/SkillTreeCanvas.tsx
@@ -1,0 +1,516 @@
+'use client';
+
+import { useRef, useEffect, useCallback } from "react"
+import { SKILL_NODES, getNodeById, type SkillNode } from "../types/data"
+
+interface Props {
+  onSelectNode: (node: SkillNode | null) => void
+  selectedNode: SkillNode | null
+  zoomAction: { type: string; ts: number } | null
+}
+
+const PX = 3 // pixel block size
+
+/* ---- helpers ---- */
+function px(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, c: string) {
+  ctx.fillStyle = c
+  ctx.fillRect(Math.round(x / PX) * PX, Math.round(y / PX) * PX, Math.max(w, PX), Math.max(h, PX))
+}
+
+function pxLine(ctx: CanvasRenderingContext2D, x0: number, y0: number, x1: number, y1: number, c: string, thick = 1) {
+  ctx.fillStyle = c
+  const dx = x1 - x0, dy = y1 - y0
+  const dist = Math.sqrt(dx * dx + dy * dy)
+  const steps = Math.max(Math.ceil(dist / PX), 1)
+  for (let i = 0; i <= steps; i++) {
+    const t = i / steps
+    const bx = x0 + dx * t, by = y0 + dy * t
+    for (let ty = 0; ty < thick; ty++)
+      for (let tx = 0; tx < thick; tx++)
+        ctx.fillRect(Math.round((bx + tx * PX) / PX) * PX, Math.round((by + ty * PX) / PX) * PX, PX, PX)
+  }
+}
+
+/* ---- palettes ---- */
+const PAL = {
+  completed: { fill: "#e8b849", hi: "#f7e8a0", lo: "#a67c20", rim: "#7a5a10" },
+  available: { fill: "#5abf5a", hi: "#b0f0b0", lo: "#2e8a2e", rim: "#1a5c1a" },
+  locked:    { fill: "#555e68", hi: "#7a8290", lo: "#3a3e44", rim: "#2a2e34" },
+}
+const CAT: Record<string, string> = {
+  web:      "#55aaff",
+  ai:       "#f0c040",
+  security: "#f06050",
+  infra:    "#50cc60",
+  design:   "#dd70ee",
+}
+
+/* ---- sparkle pool ---- */
+interface Sparkle { x: number; y: number; t: number; max: number; c: string }
+
+export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const boxRef = useRef<HTMLDivElement>(null)
+  const tf = useRef({ x: 0, y: 0, s: 0.7 })
+  const drag = useRef({ on: false, sx: 0, sy: 0, lx: 0, ly: 0 })
+  const sparks = useRef<Sparkle[]>([])
+  const raf = useRef(0)
+  const tick = useRef(0)
+
+  // zoom actions
+  useEffect(() => {
+    if (!zoomAction) return
+    const t = tf.current
+    if (zoomAction.type === "in") t.s = Math.min(t.s * 1.25, 3)
+    else if (zoomAction.type === "out") t.s = Math.max(t.s / 1.25, 0.25)
+    else { t.s = 0.7; t.x = 0; t.y = 0 }
+  }, [zoomAction])
+
+  // init sparkles
+  useEffect(() => {
+    const arr: Sparkle[] = []
+    for (const n of SKILL_NODES) {
+      if (n.status === "locked") continue
+      for (let i = 0; i < 2; i++) {
+        arr.push({
+          x: n.x + (Math.random() - 0.5) * 70,
+          y: n.y + (Math.random() - 0.5) * 70,
+          t: Math.floor(Math.random() * 50),
+          max: 50 + Math.floor(Math.random() * 40),
+          c: n.status === "completed" ? "#f7e8a0" : "#b0f0b0",
+        })
+      }
+    }
+    sparks.current = arr
+  }, [])
+
+  const toWorld = useCallback((sx: number, sy: number) => {
+    const c = canvasRef.current
+    if (!c) return { x: 0, y: 0 }
+    const t = tf.current
+    return { x: (sx - c.width / 2 - t.x) / t.s, y: (sy - c.height / 2 - t.y) / t.s }
+  }, [])
+
+  const hitNode = useCallback((wx: number, wy: number) => {
+    for (let i = SKILL_NODES.length - 1; i >= 0; i--) {
+      const n = SKILL_NODES[i]
+      if (Math.abs(wx - n.x) < 32 && Math.abs(wy - n.y) < 32) return n
+    }
+    return null
+  }, [])
+
+  /* ============ DRAW ============ */
+  useEffect(() => {
+    const canvas = canvasRef.current, box = boxRef.current
+    if (!canvas || !box) return
+    const ctx = canvas.getContext("2d")
+    if (!ctx) return
+
+    function resize() {
+      if (!canvas || !box) return
+      const dpr = window.devicePixelRatio
+      canvas.width = box.clientWidth * dpr
+      canvas.height = box.clientHeight * dpr
+      canvas.style.width = box.clientWidth + "px"
+      canvas.style.height = box.clientHeight + "px"
+    }
+    resize()
+    window.addEventListener("resize", resize)
+
+    /* ---- background: pixel grass & sky ---- */
+    function drawBg(ctx: CanvasRenderingContext2D) {
+      if (!canvas) return
+      ctx.fillStyle = "#101820"
+      ctx.fillRect(-3000, -1200, 6000, 3000)
+
+      // starry sky
+      for (let i = 0; i < 60; i++) {
+        const sx = ((i * 173 + 37) % 4000) - 2000
+        const sy = ((i * 131 + 19) % 600) - 800
+        const twinkle = Math.sin(tick.current * 0.04 + i * 2) > 0.2
+        if (twinkle) {
+          ctx.fillStyle = i % 3 === 0 ? "#667788" : "#556677"
+          ctx.fillRect(Math.round(sx / PX) * PX, Math.round(sy / PX) * PX, PX, PX)
+        }
+      }
+
+      // ground / grass strip
+      for (let gx = -2000; gx < 2000; gx += PX * 2) {
+        const gy = 620 + Math.sin(gx * 0.015) * 6
+        const gc = ((Math.floor(gx / PX) * 7) & 15) > 8 ? "#1a3a1a" : "#254a25"
+        ctx.fillStyle = gc
+        const h = PX * (2 + (Math.abs(Math.floor(gx / PX)) % 3))
+        ctx.fillRect(Math.round(gx / PX) * PX, Math.round(gy / PX) * PX, PX, h)
+      }
+      // dirt
+      ctx.fillStyle = "#2a1a0a"
+      ctx.fillRect(-2000, 640, 4000, 400)
+      ctx.fillStyle = "#3a2a1a"
+      ctx.fillRect(-2000, 640, 4000, PX * 2)
+    }
+
+    /* ---- Pixel tree trunk & branches ---- */
+    function drawTree(ctx: CanvasRenderingContext2D) {
+      const sway = Math.sin(tick.current * 0.015) * 1.5
+      const trunkC = ["#5c3a1e", "#6b4226", "#7a4e30", "#6b4226", "#5c3a1e"]
+      const hiC = "#8b6240"
+
+      // Main trunk: wide at base, narrow at top
+      for (let y = 600; y > -200; y -= PX) {
+        const prog = (600 - y) / 800
+        const w = 28 - prog * 18
+        const ci = Math.floor(((y + Math.floor(sway)) / (PX * 3)) % trunkC.length)
+        const xo = Math.sin(prog * 1.5) * 3 + sway
+        px(ctx, -w / 2 + xo, y, w, PX, trunkC[ci])
+      }
+      // trunk highlight
+      for (let y = 580; y > -180; y -= PX) {
+        const prog = (580 - y) / 760
+        const xo = Math.sin(prog * 1.5) * 3 + sway
+        px(ctx, -2 + xo, y, PX, PX, hiC)
+      }
+
+      // Big branches to each Tier-1 category
+      const tier1 = SKILL_NODES.filter(n => n.tier === 1)
+      for (const nd of tier1) {
+        // main branch from trunk split point
+        const splitY = 380 - Math.abs(nd.x) * 0.15
+        const midX = nd.x * 0.35 + sway
+        const midY = (splitY + nd.y) / 2
+
+        pxLine(ctx, sway, splitY, midX, midY, "#5c3a1e", 3)
+        pxLine(ctx, midX, midY, nd.x, nd.y + 30, "#5c3a1e", 2)
+        // highlight
+        pxLine(ctx, sway + PX, splitY - PX, midX + PX, midY - PX, hiC, 1)
+
+        // Sub-branches to tier-2 children
+        for (const cid of nd.children) {
+          const ch = getNodeById(cid)
+          if (!ch) continue
+          const cmx = (nd.x + ch.x) / 2 + sway * 0.5
+          const cmy = (nd.y + ch.y) / 2
+          pxLine(ctx, nd.x, nd.y - 18, cmx, cmy, "#4a2e14", 2)
+          pxLine(ctx, cmx, cmy, ch.x, ch.y + 24, "#4a2e14", 1)
+        }
+      }
+
+      // Deeper tier branches
+      for (const nd of SKILL_NODES) {
+        if (nd.tier < 2) continue
+        for (const cid of nd.children) {
+          const ch = getNodeById(cid)
+          if (!ch) continue
+          const cmx = (nd.x + ch.x) / 2
+          const cmy = (nd.y + ch.y) / 2
+          pxLine(ctx, nd.x, nd.y - 18, cmx, cmy, "#3d2210", 1)
+          pxLine(ctx, cmx, cmy, ch.x, ch.y + 24, "#3d2210", 1)
+        }
+      }
+    }
+
+    /* ---- Pixel leaf clusters ---- */
+    function drawLeaves(ctx: CanvasRenderingContext2D) {
+      const clusters = [
+        { x: 0, y: -500, rx: 140, ry: 80 },
+        { x: -200, y: -420, rx: 120, ry: 70 },
+        { x: 200, y: -420, rx: 120, ry: 70 },
+        { x: -400, y: -300, rx: 100, ry: 60 },
+        { x: 400, y: -300, rx: 100, ry: 60 },
+        { x: -550, y: -150, rx: 90, ry: 55 },
+        { x: 550, y: -150, rx: 90, ry: 55 },
+        { x: -350, y: -100, rx: 80, ry: 50 },
+        { x: 350, y: -100, rx: 80, ry: 50 },
+        { x: -150, y: -200, rx: 90, ry: 55 },
+        { x: 150, y: -200, rx: 90, ry: 55 },
+        { x: 0, y: -320, rx: 100, ry: 65 },
+        { x: -600, y: 20, rx: 70, ry: 45 },
+        { x: 600, y: 20, rx: 70, ry: 45 },
+        { x: -700, y: -100, rx: 60, ry: 40 },
+        { x: 700, y: -100, rx: 60, ry: 40 },
+      ]
+      const greens = ["#1a4a1a", "#255a25", "#306830", "#1e5020", "#2a6a2a", "#3a7a3a"]
+
+      for (const cl of clusters) {
+        const sw = Math.sin(tick.current * 0.01 + cl.x * 0.01) * 2
+        const srx = cl.rx / PX, sry = cl.ry / PX
+        for (let dy = -sry; dy <= sry; dy++) {
+          for (let dx = -srx; dx <= srx; dx++) {
+            const ex = dx / srx, ey = dy / sry
+            if (ex * ex + ey * ey > 1) continue
+            const hash = ((Math.abs(dx) * 7 + Math.abs(dy) * 13 + Math.floor(tick.current * 0.03)) * 31) & 255
+            if (hash > 200 && (ex * ex + ey * ey) > 0.2) continue
+            const ci = (Math.abs(dx * 3 + dy * 5) + Math.floor(tick.current * 0.01)) % greens.length
+            ctx.fillStyle = greens[ci]
+            ctx.fillRect(
+              Math.round((cl.x + dx * PX + sw) / PX) * PX,
+              Math.round((cl.y + dy * PX) / PX) * PX,
+              PX, PX
+            )
+          }
+        }
+      }
+    }
+
+    /* ---- Connection lines (on top of branches, colored by status) ---- */
+    function drawConnections(ctx: CanvasRenderingContext2D) {
+      for (const nd of SKILL_NODES) {
+        for (const cid of nd.children) {
+          const ch = getNodeById(cid)
+          if (!ch) continue
+          const both = nd.status === "completed" && ch.status === "completed"
+          const avail = nd.status === "completed" && ch.status === "available"
+          if (both) {
+            pxLine(ctx, nd.x, nd.y, ch.x, ch.y, "#e8b849", 2)
+            // animated dot
+            const sp = (tick.current * 0.02) % 1
+            const sx = nd.x + (ch.x - nd.x) * sp
+            const sy = nd.y + (ch.y - nd.y) * sp
+            px(ctx, sx - PX, sy - PX, PX * 3, PX * 3, "#f7e8a0")
+          } else if (avail) {
+            const blink = Math.sin(tick.current * 0.06) > 0
+            pxLine(ctx, nd.x, nd.y, ch.x, ch.y, blink ? "#5abf5a" : "#2e8a2e", 1)
+          } else {
+            // dashed for locked
+            const dx = ch.x - nd.x, dy = ch.y - nd.y
+            const d = Math.sqrt(dx * dx + dy * dy)
+            const segs = Math.ceil(d / (PX * 6))
+            for (let i = 0; i < segs; i += 2) {
+              const t0 = i / segs, t1 = Math.min((i + 1) / segs, 1)
+              pxLine(ctx, nd.x + dx * t0, nd.y + dy * t0, nd.x + dx * t1, nd.y + dy * t1, "#3a3e44", 1)
+            }
+          }
+        }
+      }
+    }
+
+    /* ---- Node drawing ---- */
+    function drawNode(ctx: CanvasRenderingContext2D, n: SkillNode, sel: boolean) {
+      const { x, y, status, category } = n
+      const p = PAL[status]
+      const S = 22 // half-size
+
+      // Selection bounce arrow
+      if (sel) {
+        const b = Math.sin(tick.current * 0.1) * 4
+        const ay = y - S - 18 + b
+        ctx.fillStyle = CAT[category]
+        ctx.fillRect(Math.round((x - PX) / PX) * PX, Math.round(ay / PX) * PX, PX * 2, PX * 4)
+        ctx.fillRect(Math.round((x - PX * 3) / PX) * PX, Math.round((ay + PX * 4) / PX) * PX, PX * 6, PX)
+        ctx.fillRect(Math.round((x - PX * 2) / PX) * PX, Math.round((ay + PX * 5) / PX) * PX, PX * 4, PX)
+        ctx.fillRect(Math.round((x - PX) / PX) * PX, Math.round((ay + PX * 6) / PX) * PX, PX * 2, PX)
+      }
+
+      // Category color outer ring (2px)
+      const cc = status === "locked" ? "#2a2e34" : CAT[category]
+      px(ctx, x - S - PX * 2, y - S - PX * 2, (S + PX * 2) * 2, (S + PX * 2) * 2, cc)
+
+      // Outline
+      px(ctx, x - S - PX, y - S - PX, (S + PX) * 2, (S + PX) * 2, p.rim)
+
+      // Main fill
+      px(ctx, x - S, y - S, S * 2, S * 2, p.fill)
+
+      // 3D highlight top-left
+      px(ctx, x - S, y - S, S * 2, PX, p.hi)
+      px(ctx, x - S, y - S, PX, S * 2, p.hi)
+
+      // 3D shadow bottom-right
+      px(ctx, x - S, y + S - PX, S * 2, PX, p.lo)
+      px(ctx, x + S - PX, y - S, PX, S * 2, p.lo)
+
+      // Inner icon
+      if (status === "completed") {
+        // checkmark
+        const ic = "#3d2510"
+        const pts = [[-3,-1],[-2,0],[-1,1],[0,0],[1,-1],[2,-2],[3,-3]]
+        for (const [dx, dy] of pts) px(ctx, x + dx * PX, y + dy * PX, PX, PX, ic)
+      } else if (status === "locked") {
+        // lock body
+        const ic = "#7a8290"
+        px(ctx, x - PX * 2, y - PX * 3, PX, PX * 2, ic)
+        px(ctx, x - PX, y - PX * 4, PX * 2, PX, ic)
+        px(ctx, x + PX, y - PX * 3, PX, PX * 2, ic)
+        px(ctx, x - PX * 3, y - PX, PX * 6, PX * 4, ic)
+        px(ctx, x, y + PX * 0.5, PX, PX, p.rim)
+      } else {
+        // exclamation / quest marker
+        const ic = "#1a5c1a"
+        px(ctx, x, y - PX * 3, PX, PX * 4, ic)
+        px(ctx, x, y + PX * 2, PX, PX, ic)
+      }
+
+      // Label
+      ctx.save()
+      // Use fallback if DotGothic16 is not loaded.
+      ctx.font = "bold 13px 'DotGothic16', monospace"
+      ctx.textAlign = "center"
+      ctx.textBaseline = "top"
+      // shadow
+      ctx.fillStyle = "#000"
+      // ctx.fillText(n.label, x + 1, y + S + 9)
+      // main
+      ctx.fillStyle = status === "locked" ? "#5a6068" : status === "completed" ? "#f7e8a0" : "#b0f0b0"
+      ctx.fillText(n.label, x, y + S + 8)
+      ctx.restore()
+    }
+
+    /* ---- sparkles ---- */
+    function drawSparkles(ctx: CanvasRenderingContext2D) {
+      for (const s of sparks.current) {
+        s.t++
+        if (s.t > s.max) {
+          const pool = SKILL_NODES.filter(n => n.status !== "locked")
+          const nd = pool[Math.floor(Math.random() * pool.length)]
+          if (nd) { s.x = nd.x + (Math.random() - 0.5) * 80; s.y = nd.y + (Math.random() - 0.5) * 80; s.t = 0 }
+          continue
+        }
+        if (s.t / s.max > 0.85) continue
+        const phase = Math.floor((s.t / 6) % 4)
+        ctx.fillStyle = s.c
+        const bx = Math.round(s.x / PX) * PX, by = Math.round(s.y / PX) * PX
+        if (phase === 0) {
+          ctx.fillRect(bx, by, PX, PX)
+        } else if (phase === 1) {
+          ctx.fillRect(bx, by, PX, PX)
+          ctx.fillRect(bx - PX, by, PX, PX); ctx.fillRect(bx + PX, by, PX, PX)
+          ctx.fillRect(bx, by - PX, PX, PX); ctx.fillRect(bx, by + PX, PX, PX)
+        } else if (phase === 2) {
+          ctx.fillRect(bx, by, PX, PX)
+          ctx.fillRect(bx - PX, by - PX, PX, PX); ctx.fillRect(bx + PX, by - PX, PX, PX)
+          ctx.fillRect(bx - PX, by + PX, PX, PX); ctx.fillRect(bx + PX, by + PX, PX, PX)
+        } else {
+          ctx.fillRect(bx, by, PX, PX)
+          ctx.fillRect(bx - PX, by, PX, PX); ctx.fillRect(bx + PX, by, PX, PX)
+        }
+      }
+    }
+
+    /* ---- main loop ---- */
+    function draw() {
+      if (!canvas || !ctx) return
+      tick.current++
+      const t = tf.current
+      ctx.imageSmoothingEnabled = false
+      ctx.fillStyle = "#0a1008"
+      ctx.fillRect(0, 0, canvas.width, canvas.height)
+
+      ctx.save()
+      ctx.translate(canvas.width / 2 + t.x, canvas.height / 2 + t.y)
+      ctx.scale(t.s, t.s)
+
+      drawBg(ctx)
+      drawLeaves(ctx)
+      drawTree(ctx)
+      drawConnections(ctx)
+      drawSparkles(ctx)
+
+      const sorted = [...SKILL_NODES].sort((a, b) => {
+        const o = { locked: 0, available: 1, completed: 2 } as const
+        return o[a.status] - o[b.status]
+      })
+      for (const n of sorted) drawNode(ctx, n, selectedNode?.id === n.id)
+
+      ctx.restore()
+      raf.current = requestAnimationFrame(draw)
+    }
+    draw()
+
+    return () => { window.removeEventListener("resize", resize); cancelAnimationFrame(raf.current) }
+  }, [selectedNode])
+
+  /* ============ EVENTS ============ */
+  useEffect(() => {
+    const c = canvasRef.current
+    if (!c) return
+
+    const onMD = (e: MouseEvent) => { drag.current = { on: true, sx: e.clientX, sy: e.clientY, lx: e.clientX, ly: e.clientY } }
+    const onMM = (e: MouseEvent) => {
+      if (!drag.current.on) return
+      const dpr = window.devicePixelRatio
+      tf.current.x += (e.clientX - drag.current.lx) * dpr
+      tf.current.y += (e.clientY - drag.current.ly) * dpr
+      drag.current.lx = e.clientX; drag.current.ly = e.clientY
+    }
+    const onMU = (e: MouseEvent) => {
+      const d = drag.current
+      const moved = Math.abs(e.clientX - d.sx) > 5 || Math.abs(e.clientY - d.sy) > 5
+      d.on = false
+      if (!moved) {
+        const rect = c.getBoundingClientRect()
+        const sx = (e.clientX - rect.left) * window.devicePixelRatio
+        const sy = (e.clientY - rect.top) * window.devicePixelRatio
+        const w = toWorld(sx, sy)
+        onSelectNode(hitNode(w.x, w.y))
+      }
+    }
+    const onWh = (e: WheelEvent) => {
+      // Prevent default only if Ctrl key is pressed or using pinch gesture (generic heuristic)
+      if (e.ctrlKey || e.metaKey) {
+          e.preventDefault()
+          tf.current.s = Math.max(0.25, Math.min(3, tf.current.s * (e.deltaY > 0 ? 0.92 : 1.08)))
+      }
+    }
+
+    let lastDist = 0
+    const onTS = (e: TouchEvent) => {
+      if (e.touches.length === 1) drag.current = { on: true, sx: e.touches[0].clientX, sy: e.touches[0].clientY, lx: e.touches[0].clientX, ly: e.touches[0].clientY }
+      else if (e.touches.length === 2) {
+        const dx = e.touches[0].clientX - e.touches[1].clientX
+        const dy = e.touches[0].clientY - e.touches[1].clientY
+        lastDist = Math.sqrt(dx * dx + dy * dy)
+      }
+    }
+    const onTM = (e: TouchEvent) => {
+      e.preventDefault()
+      if (e.touches.length === 1 && drag.current.on) {
+        const dpr = window.devicePixelRatio
+        tf.current.x += (e.touches[0].clientX - drag.current.lx) * dpr
+        tf.current.y += (e.touches[0].clientY - drag.current.ly) * dpr
+        drag.current.lx = e.touches[0].clientX; drag.current.ly = e.touches[0].clientY
+      } else if (e.touches.length === 2) {
+        const dx = e.touches[0].clientX - e.touches[1].clientX
+        const dy = e.touches[0].clientY - e.touches[1].clientY
+        const dist = Math.sqrt(dx * dx + dy * dy)
+        if (lastDist > 0) tf.current.s = Math.max(0.25, Math.min(3, tf.current.s * (dist / lastDist)))
+        lastDist = dist
+      }
+    }
+    const onTE = (e: TouchEvent) => {
+      if (e.touches.length === 0) {
+        const ch = e.changedTouches[0]
+        if (Math.abs(ch.clientX - drag.current.sx) < 10 && Math.abs(ch.clientY - drag.current.sy) < 10) {
+          const rect = c.getBoundingClientRect()
+          const sx = (ch.clientX - rect.left) * window.devicePixelRatio
+          const sy = (ch.clientY - rect.top) * window.devicePixelRatio
+          const w = toWorld(sx, sy)
+          onSelectNode(hitNode(w.x, w.y))
+        }
+        drag.current.on = false
+      }
+    }
+
+    c.addEventListener("mousedown", onMD)
+    window.addEventListener("mousemove", onMM)
+    window.addEventListener("mouseup", onMU)
+    c.addEventListener("wheel", onWh, { passive: false })
+    c.addEventListener("touchstart", onTS, { passive: false })
+    c.addEventListener("touchmove", onTM, { passive: false })
+    c.addEventListener("touchend", onTE)
+
+    return () => {
+      c.removeEventListener("mousedown", onMD)
+      window.removeEventListener("mousemove", onMM)
+      window.removeEventListener("mouseup", onMU)
+      c.removeEventListener("wheel", onWh)
+      c.removeEventListener("touchstart", onTS)
+      c.removeEventListener("touchmove", onTM)
+      c.removeEventListener("touchend", onTE)
+    }
+  }, [onSelectNode, toWorld, hitNode])
+
+  return (
+    <div ref={boxRef} className="absolute inset-0">
+      <canvas ref={canvasRef} className="block w-full h-full cursor-grab active:cursor-grabbing" style={{ imageRendering: "pixelated" }} />
+    </div>
+  )
+}

--- a/frontend/src/features/skill-tree/components/SkillTreeCanvas.tsx
+++ b/frontend/src/features/skill-tree/components/SkillTreeCanvas.tsx
@@ -1,33 +1,60 @@
-'use client';
+"use client";
 
-import { useRef, useEffect, useCallback } from "react"
-import { SKILL_NODES, getNodeById, type SkillNode } from "../types/data"
+import { useRef, useEffect, useCallback } from "react";
+import { SKILL_NODES, getNodeById, type SkillNode } from "../types/data";
 
 interface Props {
-  onSelectNode: (node: SkillNode | null) => void
-  selectedNode: SkillNode | null
-  zoomAction: { type: string; ts: number } | null
+  onSelectNode: (node: SkillNode | null) => void;
+  selectedNode: SkillNode | null;
+  zoomAction: { type: string; ts: number } | null;
 }
 
-const PX = 3 // pixel block size
+const PX = 3; // pixel block size
 
 /* ---- helpers ---- */
-function px(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, c: string) {
-  ctx.fillStyle = c
-  ctx.fillRect(Math.round(x / PX) * PX, Math.round(y / PX) * PX, Math.max(w, PX), Math.max(h, PX))
+function px(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  c: string,
+) {
+  ctx.fillStyle = c;
+  ctx.fillRect(
+    Math.round(x / PX) * PX,
+    Math.round(y / PX) * PX,
+    Math.max(w, PX),
+    Math.max(h, PX),
+  );
 }
 
-function pxLine(ctx: CanvasRenderingContext2D, x0: number, y0: number, x1: number, y1: number, c: string, thick = 1) {
-  ctx.fillStyle = c
-  const dx = x1 - x0, dy = y1 - y0
-  const dist = Math.sqrt(dx * dx + dy * dy)
-  const steps = Math.max(Math.ceil(dist / PX), 1)
+function pxLine(
+  ctx: CanvasRenderingContext2D,
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number,
+  c: string,
+  thick = 1,
+) {
+  ctx.fillStyle = c;
+  const dx = x1 - x0,
+    dy = y1 - y0;
+  const dist = Math.sqrt(dx * dx + dy * dy);
+  const steps = Math.max(Math.ceil(dist / PX), 1);
   for (let i = 0; i <= steps; i++) {
-    const t = i / steps
-    const bx = x0 + dx * t, by = y0 + dy * t
+    const t = i / steps;
+    const bx = x0 + dx * t,
+      by = y0 + dy * t;
     for (let ty = 0; ty < thick; ty++)
       for (let tx = 0; tx < thick; tx++)
-        ctx.fillRect(Math.round((bx + tx * PX) / PX) * PX, Math.round((by + ty * PX) / PX) * PX, PX, PX)
+        ctx.fillRect(
+          Math.round((bx + tx * PX) / PX) * PX,
+          Math.round((by + ty * PX) / PX) * PX,
+          PX,
+          PX,
+        );
   }
 }
 
@@ -35,42 +62,56 @@ function pxLine(ctx: CanvasRenderingContext2D, x0: number, y0: number, x1: numbe
 const PAL = {
   completed: { fill: "#e8b849", hi: "#f7e8a0", lo: "#a67c20", rim: "#7a5a10" },
   available: { fill: "#5abf5a", hi: "#b0f0b0", lo: "#2e8a2e", rim: "#1a5c1a" },
-  locked:    { fill: "#555e68", hi: "#7a8290", lo: "#3a3e44", rim: "#2a2e34" },
-}
+  locked: { fill: "#555e68", hi: "#7a8290", lo: "#3a3e44", rim: "#2a2e34" },
+};
 const CAT: Record<string, string> = {
-  web:      "#55aaff",
-  ai:       "#f0c040",
+  web: "#55aaff",
+  ai: "#f0c040",
   security: "#f06050",
-  infra:    "#50cc60",
-  design:   "#dd70ee",
-}
+  infra: "#50cc60",
+  design: "#dd70ee",
+};
 
 /* ---- sparkle pool ---- */
-interface Sparkle { x: number; y: number; t: number; max: number; c: string }
+interface Sparkle {
+  x: number;
+  y: number;
+  t: number;
+  max: number;
+  c: string;
+}
 
-export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Props) {
-  const canvasRef = useRef<HTMLCanvasElement>(null)
-  const boxRef = useRef<HTMLDivElement>(null)
-  const tf = useRef({ x: 0, y: 0, s: 0.7 })
-  const drag = useRef({ on: false, sx: 0, sy: 0, lx: 0, ly: 0 })
-  const sparks = useRef<Sparkle[]>([])
-  const raf = useRef(0)
-  const tick = useRef(0)
+export function SkillTreeCanvas({
+  onSelectNode,
+  selectedNode,
+  zoomAction,
+}: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const boxRef = useRef<HTMLDivElement>(null);
+  const tf = useRef({ x: 0, y: 0, s: 0.7 });
+  const drag = useRef({ on: false, sx: 0, sy: 0, lx: 0, ly: 0 });
+  const sparks = useRef<Sparkle[]>([]);
+  const raf = useRef(0);
+  const tick = useRef(0);
 
   // zoom actions
   useEffect(() => {
-    if (!zoomAction) return
-    const t = tf.current
-    if (zoomAction.type === "in") t.s = Math.min(t.s * 1.25, 3)
-    else if (zoomAction.type === "out") t.s = Math.max(t.s / 1.25, 0.7)
-    else { t.s = 0.7; t.x = 0; t.y = 0 }
-  }, [zoomAction])
+    if (!zoomAction) return;
+    const t = tf.current;
+    if (zoomAction.type === "in") t.s = Math.min(t.s * 1.25, 3);
+    else if (zoomAction.type === "out") t.s = Math.max(t.s / 1.25, 0.7);
+    else {
+      t.s = 0.7;
+      t.x = 0;
+      t.y = 0;
+    }
+  }, [zoomAction]);
 
   // init sparkles
   useEffect(() => {
-    const arr: Sparkle[] = []
+    const arr: Sparkle[] = [];
     for (const n of SKILL_NODES) {
-      if (n.status === "locked") continue
+      if (n.status === "locked") continue;
       for (let i = 0; i < 2; i++) {
         arr.push({
           x: n.x + (Math.random() - 0.5) * 70,
@@ -78,103 +119,114 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
           t: Math.floor(Math.random() * 50),
           max: 50 + Math.floor(Math.random() * 40),
           c: n.status === "completed" ? "#f7e8a0" : "#b0f0b0",
-        })
+        });
       }
     }
-    sparks.current = arr
-  }, [])
+    sparks.current = arr;
+  }, []);
 
   const toWorld = useCallback((sx: number, sy: number) => {
-    const c = canvasRef.current
-    if (!c) return { x: 0, y: 0 }
-    const t = tf.current
-    return { x: (sx - c.width / 2 - t.x) / t.s, y: (sy - c.height / 2 - t.y) / t.s }
-  }, [])
+    const c = canvasRef.current;
+    if (!c) return { x: 0, y: 0 };
+    const t = tf.current;
+    return {
+      x: (sx - c.width / 2 - t.x) / t.s,
+      y: (sy - c.height / 2 - t.y) / t.s,
+    };
+  }, []);
 
   const hitNode = useCallback((wx: number, wy: number) => {
     for (let i = SKILL_NODES.length - 1; i >= 0; i--) {
-      const n = SKILL_NODES[i]
-      if (Math.abs(wx - n.x) < 32 && Math.abs(wy - n.y) < 32) return n
+      const n = SKILL_NODES[i];
+      if (Math.abs(wx - n.x) < 32 && Math.abs(wy - n.y) < 32) return n;
     }
-    return null
-  }, [])
+    return null;
+  }, []);
 
   /* ============ DRAW ============ */
   useEffect(() => {
-    const canvas = canvasRef.current, box = boxRef.current
-    if (!canvas || !box) return
-    const ctx = canvas.getContext("2d")
-    if (!ctx) return
+    const canvas = canvasRef.current,
+      box = boxRef.current;
+    if (!canvas || !box) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
 
     function resize() {
-      if (!canvas || !box) return
-      const dpr = window.devicePixelRatio
-      canvas.width = box.clientWidth * dpr
-      canvas.height = box.clientHeight * dpr
-      canvas.style.width = box.clientWidth + "px"
-      canvas.style.height = box.clientHeight + "px"
+      if (!canvas || !box) return;
+      const dpr = window.devicePixelRatio;
+      canvas.width = box.clientWidth * dpr;
+      canvas.height = box.clientHeight * dpr;
+      canvas.style.width = box.clientWidth + "px";
+      canvas.style.height = box.clientHeight + "px";
     }
-    resize()
-    window.addEventListener("resize", resize)
+    resize();
+    window.addEventListener("resize", resize);
 
     /* ---- background: pixel grass & sky ---- */
     function drawBg(ctx: CanvasRenderingContext2D) {
-      if (!canvas) return
-      ctx.fillStyle = "#101820"
-      ctx.fillRect(-3000, -1200, 6000, 3000)
+      if (!canvas) return;
+      ctx.fillStyle = "#101820";
+      ctx.fillRect(-3000, -1200, 6000, 3000);
 
       // starry sky
       for (let i = 0; i < 60; i++) {
-        const sx = ((i * 173 + 37) % 4000) - 2000
-        const sy = ((i * 131 + 19) % 600) - 800
-        const twinkle = Math.sin(tick.current * 0.04 + i * 2) > 0.2
+        const sx = ((i * 173 + 37) % 4000) - 2000;
+        const sy = ((i * 131 + 19) % 600) - 800;
+        const twinkle = Math.sin(tick.current * 0.04 + i * 2) > 0.2;
         if (twinkle) {
-          ctx.fillStyle = i % 3 === 0 ? "#667788" : "#556677"
-          ctx.fillRect(Math.round(sx / PX) * PX, Math.round(sy / PX) * PX, PX, PX)
+          ctx.fillStyle = i % 3 === 0 ? "#667788" : "#556677";
+          ctx.fillRect(
+            Math.round(sx / PX) * PX,
+            Math.round(sy / PX) * PX,
+            PX,
+            PX,
+          );
         }
       }
 
       // ground / grass strip
       for (let gx = -2000; gx < 2000; gx += PX * 2) {
-        const gy = 620 + Math.sin(gx * 0.015) * 6
-        const gc = ((Math.floor(gx / PX) * 7) & 15) > 8 ? "#1a3a1a" : "#254a25"
-        ctx.fillStyle = gc
-        const h = PX * (2 + (Math.abs(Math.floor(gx / PX)) % 3))
-        ctx.fillRect(Math.round(gx / PX) * PX, Math.round(gy / PX) * PX, PX, h)
+        const gy = 620 + Math.sin(gx * 0.015) * 6;
+        const gc = ((Math.floor(gx / PX) * 7) & 15) > 8 ? "#1a3a1a" : "#254a25";
+        ctx.fillStyle = gc;
+        const h = PX * (2 + (Math.abs(Math.floor(gx / PX)) % 3));
+        ctx.fillRect(Math.round(gx / PX) * PX, Math.round(gy / PX) * PX, PX, h);
       }
       // dirt
-      ctx.fillStyle = "#2a1a0a"
-      ctx.fillRect(-2000, 640, 4000, 400)
-      ctx.fillStyle = "#3a2a1a"
-      ctx.fillRect(-2000, 640, 4000, PX * 2)
+      ctx.fillStyle = "#2a1a0a";
+      ctx.fillRect(-2000, 640, 4000, 400);
+      ctx.fillStyle = "#3a2a1a";
+      ctx.fillRect(-2000, 640, 4000, PX * 2);
     }
 
     /* ---- Pixel tree trunk & branches ---- */
     function drawTree(ctx: CanvasRenderingContext2D) {
-      const sway = Math.sin(tick.current * 0.015) * 1.5
-      const trunkC = ["#5c3a1e", "#6b4226", "#7a4e30", "#6b4226", "#5c3a1e"]
-      const hiC = "#8b6240"
+      const sway = Math.sin(tick.current * 0.015) * 1.5;
+      const trunkC = ["#5c3a1e", "#6b4226", "#7a4e30", "#6b4226", "#5c3a1e"];
 
       // Trunk: 地面(y=632) → Rootノード(y=400) まで。下が太く上（Root）が細い
-      const trunkTop = 400
-      const trunkBot = 632
-      const totalH = trunkBot - trunkTop   // 232px
+      const trunkTop = 400;
+      const trunkBot = 632;
+      const totalH = trunkBot - trunkTop; // 232px
       for (let y = trunkBot; y >= trunkTop; y -= PX) {
-        const prog = (trunkBot - y) / totalH  // 0=地面（太い）, 1=Root（細い）
-        const w = Math.round(44 - prog * 32)  // 44px → 12px
-        const ci = Math.floor(((Math.abs(y) + Math.floor(sway)) / (PX * 3)) % trunkC.length)
-        const xo = Math.sin(prog * 2.0 + tick.current * 0.015) * prog * 3 + sway
-        px(ctx, -w / 2 + xo, y, w, PX, trunkC[ci])
+        const prog = (trunkBot - y) / totalH; // 0=地面（太い）, 1=Root（細い）
+        const w = Math.round(44 - prog * 32); // 44px → 12px
+        const ci = Math.floor(
+          ((Math.abs(y) + Math.floor(sway)) / (PX * 3)) % trunkC.length,
+        );
+        const xo =
+          Math.sin(prog * 2.0 + tick.current * 0.015) * prog * 3 + sway;
+        px(ctx, -w / 2 + xo, y, w, PX, trunkC[ci]);
       }
-      
+
       // Generic connection loop for all nodes
       for (const nd of SKILL_NODES) {
         for (const cid of nd.children) {
-          const ch = getNodeById(cid)
-          if (!ch) continue
+          const ch = getNodeById(cid);
+          if (!ch) continue;
 
           // Draw branches behind connections
-          pxLine(ctx, nd.x, nd.y - 20, ch.x, ch.y + 20, "#5c3a1e", 3)
+          pxLine(ctx, nd.x, nd.y - 20, ch.x, ch.y + 20, "#5c3a1e", 3);
         }
       }
     }
@@ -188,51 +240,68 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
 
         // Tier 1 (y=200) - span ±1100（最広）
         { x: -1100, y: 200, rx: 118, ry: 64 },
-        { x:  -550, y: 200, rx: 110, ry: 60 },
-        { x:     0, y: 200, rx: 110, ry: 60 },
-        { x:   550, y: 200, rx: 110, ry: 60 },
-        { x:  1100, y: 200, rx: 118, ry: 64 },
+        { x: -550, y: 200, rx: 110, ry: 60 },
+        { x: 0, y: 200, rx: 110, ry: 60 },
+        { x: 550, y: 200, rx: 110, ry: 60 },
+        { x: 1100, y: 200, rx: 118, ry: 64 },
 
         // Tier 2 (y=0) - span ±900
-        { x: -900, y: 0, rx:  95, ry: 52 },
-        { x: -460, y: 0, rx:  90, ry: 50 },
-        { x:    0, y: 0, rx:  90, ry: 50 },
-        { x:  460, y: 0, rx:  90, ry: 50 },
-        { x:  900, y: 0, rx:  95, ry: 52 },
+        { x: -900, y: 0, rx: 95, ry: 52 },
+        { x: -460, y: 0, rx: 90, ry: 50 },
+        { x: 0, y: 0, rx: 90, ry: 50 },
+        { x: 460, y: 0, rx: 90, ry: 50 },
+        { x: 900, y: 0, rx: 95, ry: 52 },
 
         // Tier 3 (y=-200) - span ±700
-        { x: -700, y: -200, rx:  90, ry: 50 },
-        { x: -390, y: -200, rx:  86, ry: 48 },
-        { x:  -80, y: -200, rx:  86, ry: 48 },
-        { x:   80, y: -200, rx:  86, ry: 48 },
-        { x:  390, y: -200, rx:  86, ry: 48 },
-        { x:  700, y: -200, rx:  90, ry: 50 },
+        { x: -700, y: -200, rx: 90, ry: 50 },
+        { x: -390, y: -200, rx: 86, ry: 48 },
+        { x: -80, y: -200, rx: 86, ry: 48 },
+        { x: 80, y: -200, rx: 86, ry: 48 },
+        { x: 390, y: -200, rx: 86, ry: 48 },
+        { x: 700, y: -200, rx: 90, ry: 50 },
 
         // Tier 4 (y=-400) - span ±400（最も狭い）
-        { x: -400, y: -400, rx:  78, ry: 44 },
-        { x: -200, y: -400, rx:  74, ry: 42 },
-        { x:    0, y: -400, rx:  74, ry: 42 },
-        { x:   200, y: -400, rx:  74, ry: 42 },
-        { x:   400, y: -400, rx:  78, ry: 44 },
-      ]
-      const greens = ["#1a4a1a", "#255a25", "#306830", "#1e5020", "#2a6a2a", "#3a7a3a"]
+        { x: -400, y: -400, rx: 78, ry: 44 },
+        { x: -200, y: -400, rx: 74, ry: 42 },
+        { x: 0, y: -400, rx: 74, ry: 42 },
+        { x: 200, y: -400, rx: 74, ry: 42 },
+        { x: 400, y: -400, rx: 78, ry: 44 },
+      ];
+      const greens = [
+        "#1a4a1a",
+        "#255a25",
+        "#306830",
+        "#1e5020",
+        "#2a6a2a",
+        "#3a7a3a",
+      ];
 
       for (const cl of clusters) {
-        const sw = Math.sin(tick.current * 0.01 + cl.x * 0.01) * 2
-        const srx = cl.rx / PX, sry = cl.ry / PX
+        const sw = Math.sin(tick.current * 0.01 + cl.x * 0.01) * 2;
+        const srx = cl.rx / PX,
+          sry = cl.ry / PX;
         for (let dy = -sry; dy <= sry; dy++) {
           for (let dx = -srx; dx <= srx; dx++) {
-            const ex = dx / srx, ey = dy / sry
-            if (ex * ex + ey * ey > 1) continue
-            const hash = ((Math.abs(dx) * 7 + Math.abs(dy) * 13 + Math.floor(tick.current * 0.03)) * 31) & 255
-            if (hash > 200 && (ex * ex + ey * ey) > 0.2) continue
-            const ci = (Math.abs(dx * 3 + dy * 5) + Math.floor(tick.current * 0.01)) % greens.length
-            ctx.fillStyle = greens[ci]
+            const ex = dx / srx,
+              ey = dy / sry;
+            if (ex * ex + ey * ey > 1) continue;
+            const hash =
+              ((Math.abs(dx) * 7 +
+                Math.abs(dy) * 13 +
+                Math.floor(tick.current * 0.03)) *
+                31) &
+              255;
+            if (hash > 200 && ex * ex + ey * ey > 0.2) continue;
+            const ci =
+              (Math.abs(dx * 3 + dy * 5) + Math.floor(tick.current * 0.01)) %
+              greens.length;
+            ctx.fillStyle = greens[ci];
             ctx.fillRect(
               Math.round((cl.x + dx * PX + sw) / PX) * PX,
               Math.round((cl.y + dy * PX) / PX) * PX,
-              PX, PX
-            )
+              PX,
+              PX,
+            );
           }
         }
       }
@@ -242,28 +311,46 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
     function drawConnections(ctx: CanvasRenderingContext2D) {
       for (const nd of SKILL_NODES) {
         for (const cid of nd.children) {
-          const ch = getNodeById(cid)
-          if (!ch) continue
-          const both = nd.status === "completed" && ch.status === "completed"
-          const avail = nd.status === "completed" && ch.status === "available"
+          const ch = getNodeById(cid);
+          if (!ch) continue;
+          const both = nd.status === "completed" && ch.status === "completed";
+          const avail = nd.status === "completed" && ch.status === "available";
           if (both) {
-            pxLine(ctx, nd.x, nd.y, ch.x, ch.y, "#e8b849", 2)
+            pxLine(ctx, nd.x, nd.y, ch.x, ch.y, "#e8b849", 2);
             // animated dot
-            const sp = (tick.current * 0.02) % 1
-            const sx = nd.x + (ch.x - nd.x) * sp
-            const sy = nd.y + (ch.y - nd.y) * sp
-            px(ctx, sx - PX, sy - PX, PX * 3, PX * 3, "#f7e8a0")
+            const sp = (tick.current * 0.02) % 1;
+            const sx = nd.x + (ch.x - nd.x) * sp;
+            const sy = nd.y + (ch.y - nd.y) * sp;
+            px(ctx, sx - PX, sy - PX, PX * 3, PX * 3, "#f7e8a0");
           } else if (avail) {
-            const blink = Math.sin(tick.current * 0.06) > 0
-            pxLine(ctx, nd.x, nd.y, ch.x, ch.y, blink ? "#5abf5a" : "#2e8a2e", 1)
+            const blink = Math.sin(tick.current * 0.06) > 0;
+            pxLine(
+              ctx,
+              nd.x,
+              nd.y,
+              ch.x,
+              ch.y,
+              blink ? "#5abf5a" : "#2e8a2e",
+              1,
+            );
           } else {
             // dashed for locked
-            const dx = ch.x - nd.x, dy = ch.y - nd.y
-            const d = Math.sqrt(dx * dx + dy * dy)
-            const segs = Math.ceil(d / (PX * 6))
+            const dx = ch.x - nd.x,
+              dy = ch.y - nd.y;
+            const d = Math.sqrt(dx * dx + dy * dy);
+            const segs = Math.ceil(d / (PX * 6));
             for (let i = 0; i < segs; i += 2) {
-              const t0 = i / segs, t1 = Math.min((i + 1) / segs, 1)
-              pxLine(ctx, nd.x + dx * t0, nd.y + dy * t0, nd.x + dx * t1, nd.y + dy * t1, "#3a3e44", 1)
+              const t0 = i / segs,
+                t1 = Math.min((i + 1) / segs, 1);
+              pxLine(
+                ctx,
+                nd.x + dx * t0,
+                nd.y + dy * t0,
+                nd.x + dx * t1,
+                nd.y + dy * t1,
+                "#3a3e44",
+                1,
+              );
             }
           }
         }
@@ -271,221 +358,312 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
     }
 
     /* ---- Node drawing ---- */
-    function drawNode(ctx: CanvasRenderingContext2D, n: SkillNode, sel: boolean) {
-      const { x, y, status, category } = n
-      const p = PAL[status]
-      const S = 22 // half-size
+    function drawNode(
+      ctx: CanvasRenderingContext2D,
+      n: SkillNode,
+      sel: boolean,
+    ) {
+      const { x, y, status, category } = n;
+      const p = PAL[status];
+      const S = 22; // half-size
 
       // Selection bounce arrow
       if (sel) {
-        const b = Math.sin(tick.current * 0.1) * 4
-        const ay = y - S - 18 + b
-        ctx.fillStyle = CAT[category]
-        ctx.fillRect(Math.round((x - PX) / PX) * PX, Math.round(ay / PX) * PX, PX * 2, PX * 4)
-        ctx.fillRect(Math.round((x - PX * 3) / PX) * PX, Math.round((ay + PX * 4) / PX) * PX, PX * 6, PX)
-        ctx.fillRect(Math.round((x - PX * 2) / PX) * PX, Math.round((ay + PX * 5) / PX) * PX, PX * 4, PX)
-        ctx.fillRect(Math.round((x - PX) / PX) * PX, Math.round((ay + PX * 6) / PX) * PX, PX * 2, PX)
+        const b = Math.sin(tick.current * 0.1) * 4;
+        const ay = y - S - 18 + b;
+        ctx.fillStyle = CAT[category];
+        ctx.fillRect(
+          Math.round((x - PX) / PX) * PX,
+          Math.round(ay / PX) * PX,
+          PX * 2,
+          PX * 4,
+        );
+        ctx.fillRect(
+          Math.round((x - PX * 3) / PX) * PX,
+          Math.round((ay + PX * 4) / PX) * PX,
+          PX * 6,
+          PX,
+        );
+        ctx.fillRect(
+          Math.round((x - PX * 2) / PX) * PX,
+          Math.round((ay + PX * 5) / PX) * PX,
+          PX * 4,
+          PX,
+        );
+        ctx.fillRect(
+          Math.round((x - PX) / PX) * PX,
+          Math.round((ay + PX * 6) / PX) * PX,
+          PX * 2,
+          PX,
+        );
       }
 
       // Category color outer ring (3px)
-      const cc = status === "locked" ? "#2a2e34" : CAT[category]
-      px(ctx, x - S - PX * 3, y - S - PX * 3, (S + PX * 3) * 2, (S + PX * 3) * 2, cc)
+      const cc = status === "locked" ? "#2a2e34" : CAT[category];
+      px(
+        ctx,
+        x - S - PX * 3,
+        y - S - PX * 3,
+        (S + PX * 3) * 2,
+        (S + PX * 3) * 2,
+        cc,
+      );
 
       // Outline
-      px(ctx, x - S - PX, y - S - PX, (S + PX) * 2, (S + PX) * 2, p.rim)
+      px(ctx, x - S - PX, y - S - PX, (S + PX) * 2, (S + PX) * 2, p.rim);
 
       // Main fill
-      px(ctx, x - S, y - S, S * 2, S * 2, p.fill)
+      px(ctx, x - S, y - S, S * 2, S * 2, p.fill);
 
       // 3D highlight top-left
-      px(ctx, x - S, y - S, S * 2, PX, p.hi)
-      px(ctx, x - S, y - S, PX, S * 2, p.hi)
+      px(ctx, x - S, y - S, S * 2, PX, p.hi);
+      px(ctx, x - S, y - S, PX, S * 2, p.hi);
 
       // 3D shadow bottom-right
-      px(ctx, x - S, y + S - PX, S * 2, PX, p.lo)
-      px(ctx, x + S - PX, y - S, PX, S * 2, p.lo)
+      px(ctx, x - S, y + S - PX, S * 2, PX, p.lo);
+      px(ctx, x + S - PX, y - S, PX, S * 2, p.lo);
 
       // Inner icon
       if (status === "completed") {
         // checkmark
-        const ic = "#3d2510"
-        const pts = [[-3,-1],[-2,0],[-1,1],[0,0],[1,-1],[2,-2],[3,-3]]
-        for (const [dx, dy] of pts) px(ctx, x + dx * PX, y + dy * PX, PX, PX, ic)
+        const ic = "#3d2510";
+        const pts = [
+          [-3, -1],
+          [-2, 0],
+          [-1, 1],
+          [0, 0],
+          [1, -1],
+          [2, -2],
+          [3, -3],
+        ];
+        for (const [dx, dy] of pts)
+          px(ctx, x + dx * PX, y + dy * PX, PX, PX, ic);
       } else if (status === "locked") {
         // lock body
-        const ic = "#7a8290"
-        px(ctx, x - PX * 2, y - PX * 3, PX, PX * 2, ic)
-        px(ctx, x - PX, y - PX * 4, PX * 2, PX, ic)
-        px(ctx, x + PX, y - PX * 3, PX, PX * 2, ic)
-        px(ctx, x - PX * 3, y - PX, PX * 6, PX * 4, ic)
-        px(ctx, x, y + PX * 0.5, PX, PX, p.rim)
+        const ic = "#7a8290";
+        px(ctx, x - PX * 2, y - PX * 3, PX, PX * 2, ic);
+        px(ctx, x - PX, y - PX * 4, PX * 2, PX, ic);
+        px(ctx, x + PX, y - PX * 3, PX, PX * 2, ic);
+        px(ctx, x - PX * 3, y - PX, PX * 6, PX * 4, ic);
+        px(ctx, x, y + PX * 0.5, PX, PX, p.rim);
       } else {
         // exclamation / quest marker
-        const ic = "#1a5c1a"
-        px(ctx, x, y - PX * 3, PX, PX * 4, ic)
-        px(ctx, x, y + PX * 2, PX, PX, ic)
+        const ic = "#1a5c1a";
+        px(ctx, x, y - PX * 3, PX, PX * 4, ic);
+        px(ctx, x, y + PX * 2, PX, PX, ic);
       }
 
       // Label
-      ctx.save()
+      ctx.save();
       // Use fallback if DotGothic16 is not loaded.
-      ctx.font = "bold 21px 'DotGothic16', monospace"
-      ctx.textAlign = "center"
-      ctx.textBaseline = "top"
+      ctx.font = "bold 21px 'DotGothic16', monospace";
+      ctx.textAlign = "center";
+      ctx.textBaseline = "top";
       // shadow
-      ctx.fillStyle = "#000"
+      ctx.fillStyle = "#000";
       // ctx.fillText(n.label, x + 1, y + S + 9)
       // main
-      ctx.fillStyle = status === "locked" ? "#5a6068" : status === "completed" ? "#f7e8a0" : "#b0f0b0"
-      ctx.fillText(n.label, x, y + S + 8)
-      ctx.restore()
+      ctx.fillStyle =
+        status === "locked"
+          ? "#5a6068"
+          : status === "completed"
+            ? "#f7e8a0"
+            : "#b0f0b0";
+      ctx.fillText(n.label, x, y + S + 8);
+      ctx.restore();
     }
 
     /* ---- sparkles ---- */
     function drawSparkles(ctx: CanvasRenderingContext2D) {
       for (const s of sparks.current) {
-        s.t++
+        s.t++;
         if (s.t > s.max) {
-          const pool = SKILL_NODES.filter(n => n.status !== "locked")
-          const nd = pool[Math.floor(Math.random() * pool.length)]
-          if (nd) { s.x = nd.x + (Math.random() - 0.5) * 80; s.y = nd.y + (Math.random() - 0.5) * 80; s.t = 0 }
-          continue
+          const pool = SKILL_NODES.filter((n) => n.status !== "locked");
+          const nd = pool[Math.floor(Math.random() * pool.length)];
+          if (nd) {
+            s.x = nd.x + (Math.random() - 0.5) * 80;
+            s.y = nd.y + (Math.random() - 0.5) * 80;
+            s.t = 0;
+          }
+          continue;
         }
-        if (s.t / s.max > 0.85) continue
-        const phase = Math.floor((s.t / 6) % 4)
-        ctx.fillStyle = s.c
-        const bx = Math.round(s.x / PX) * PX, by = Math.round(s.y / PX) * PX
+        if (s.t / s.max > 0.85) continue;
+        const phase = Math.floor((s.t / 6) % 4);
+        ctx.fillStyle = s.c;
+        const bx = Math.round(s.x / PX) * PX,
+          by = Math.round(s.y / PX) * PX;
         if (phase === 0) {
-          ctx.fillRect(bx, by, PX, PX)
+          ctx.fillRect(bx, by, PX, PX);
         } else if (phase === 1) {
-          ctx.fillRect(bx, by, PX, PX)
-          ctx.fillRect(bx - PX, by, PX, PX); ctx.fillRect(bx + PX, by, PX, PX)
-          ctx.fillRect(bx, by - PX, PX, PX); ctx.fillRect(bx, by + PX, PX, PX)
+          ctx.fillRect(bx, by, PX, PX);
+          ctx.fillRect(bx - PX, by, PX, PX);
+          ctx.fillRect(bx + PX, by, PX, PX);
+          ctx.fillRect(bx, by - PX, PX, PX);
+          ctx.fillRect(bx, by + PX, PX, PX);
         } else if (phase === 2) {
-          ctx.fillRect(bx, by, PX, PX)
-          ctx.fillRect(bx - PX, by - PX, PX, PX); ctx.fillRect(bx + PX, by - PX, PX, PX)
-          ctx.fillRect(bx - PX, by + PX, PX, PX); ctx.fillRect(bx + PX, by + PX, PX, PX)
+          ctx.fillRect(bx, by, PX, PX);
+          ctx.fillRect(bx - PX, by - PX, PX, PX);
+          ctx.fillRect(bx + PX, by - PX, PX, PX);
+          ctx.fillRect(bx - PX, by + PX, PX, PX);
+          ctx.fillRect(bx + PX, by + PX, PX, PX);
         } else {
-          ctx.fillRect(bx, by, PX, PX)
-          ctx.fillRect(bx - PX, by, PX, PX); ctx.fillRect(bx + PX, by, PX, PX)
+          ctx.fillRect(bx, by, PX, PX);
+          ctx.fillRect(bx - PX, by, PX, PX);
+          ctx.fillRect(bx + PX, by, PX, PX);
         }
       }
     }
 
     /* ---- main loop ---- */
     function draw() {
-      if (!canvas || !ctx) return
-      tick.current++
-      const t = tf.current
-      ctx.imageSmoothingEnabled = false
-      ctx.fillStyle = "#0a1008"
-      ctx.fillRect(0, 0, canvas.width, canvas.height)
+      if (!canvas || !ctx) return;
+      tick.current++;
+      const t = tf.current;
+      ctx.imageSmoothingEnabled = false;
+      ctx.fillStyle = "#0a1008";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-      ctx.save()
-      ctx.translate(canvas.width / 2 + t.x, canvas.height / 2 + t.y)
-      ctx.scale(t.s, t.s)
+      ctx.save();
+      ctx.translate(canvas.width / 2 + t.x, canvas.height / 2 + t.y);
+      ctx.scale(t.s, t.s);
 
-      drawBg(ctx)
-      drawLeaves(ctx)
-      drawTree(ctx)
-      drawConnections(ctx)
-      drawSparkles(ctx)
+      drawBg(ctx);
+      drawLeaves(ctx);
+      drawTree(ctx);
+      drawConnections(ctx);
+      drawSparkles(ctx);
 
       const sorted = [...SKILL_NODES].sort((a, b) => {
-        const o = { locked: 0, available: 1, completed: 2 } as const
-        return o[a.status] - o[b.status]
-      })
-      for (const n of sorted) drawNode(ctx, n, selectedNode?.id === n.id)
+        const o = { locked: 0, available: 1, completed: 2 } as const;
+        return o[a.status] - o[b.status];
+      });
+      for (const n of sorted) drawNode(ctx, n, selectedNode?.id === n.id);
 
-      ctx.restore()
-      raf.current = requestAnimationFrame(draw)
+      ctx.restore();
+      raf.current = requestAnimationFrame(draw);
     }
-    draw()
+    draw();
 
-    return () => { window.removeEventListener("resize", resize); cancelAnimationFrame(raf.current) }
-  }, [selectedNode])
+    return () => {
+      window.removeEventListener("resize", resize);
+      cancelAnimationFrame(raf.current);
+    };
+  }, [selectedNode]);
 
   /* ============ EVENTS ============ */
   useEffect(() => {
-    const c = canvasRef.current
-    if (!c) return
+    const c = canvasRef.current;
+    if (!c) return;
 
-    const onMD = (e: MouseEvent) => { drag.current = { on: false, sx: e.clientX, sy: e.clientY, lx: e.clientX, ly: e.clientY } }
-    const onMM = (_e: MouseEvent) => { /* drag disabled */ }
+    const onMD = (e: MouseEvent) => {
+      drag.current = {
+        on: false,
+        sx: e.clientX,
+        sy: e.clientY,
+        lx: e.clientX,
+        ly: e.clientY,
+      };
+    };
+    const onMM = () => {
+      /* drag disabled */
+    };
     const onMU = (e: MouseEvent) => {
-      const d = drag.current
-      const moved = Math.abs(e.clientX - d.sx) > 5 || Math.abs(e.clientY - d.sy) > 5
+      const d = drag.current;
+      const moved =
+        Math.abs(e.clientX - d.sx) > 5 || Math.abs(e.clientY - d.sy) > 5;
       if (!moved) {
-        const rect = c.getBoundingClientRect()
-        const sx = (e.clientX - rect.left) * window.devicePixelRatio
-        const sy = (e.clientY - rect.top) * window.devicePixelRatio
-        const w = toWorld(sx, sy)
-        onSelectNode(hitNode(w.x, w.y))
+        const rect = c.getBoundingClientRect();
+        const sx = (e.clientX - rect.left) * window.devicePixelRatio;
+        const sy = (e.clientY - rect.top) * window.devicePixelRatio;
+        const w = toWorld(sx, sy);
+        onSelectNode(hitNode(w.x, w.y));
       }
-    }
+    };
     const onWh = (e: WheelEvent) => {
       // Prevent default only if Ctrl key is pressed or using pinch gesture (generic heuristic)
       if (e.ctrlKey || e.metaKey) {
-          e.preventDefault()
-          tf.current.s = Math.max(0.7, Math.min(3, tf.current.s * (e.deltaY > 0 ? 0.92 : 1.08)))
+        e.preventDefault();
+        tf.current.s = Math.max(
+          0.7,
+          Math.min(3, tf.current.s * (e.deltaY > 0 ? 0.92 : 1.08)),
+        );
       }
-    }
+    };
 
-    let lastDist = 0
+    let lastDist = 0;
     const onTS = (e: TouchEvent) => {
-      if (e.touches.length === 1) drag.current = { on: false, sx: e.touches[0].clientX, sy: e.touches[0].clientY, lx: e.touches[0].clientX, ly: e.touches[0].clientY }
+      if (e.touches.length === 1)
+        drag.current = {
+          on: false,
+          sx: e.touches[0].clientX,
+          sy: e.touches[0].clientY,
+          lx: e.touches[0].clientX,
+          ly: e.touches[0].clientY,
+        };
       else if (e.touches.length === 2) {
-        const dx = e.touches[0].clientX - e.touches[1].clientX
-        const dy = e.touches[0].clientY - e.touches[1].clientY
-        lastDist = Math.sqrt(dx * dx + dy * dy)
+        const dx = e.touches[0].clientX - e.touches[1].clientX;
+        const dy = e.touches[0].clientY - e.touches[1].clientY;
+        lastDist = Math.sqrt(dx * dx + dy * dy);
       }
-    }
+    };
     const onTM = (e: TouchEvent) => {
-      e.preventDefault()
-      if (e.touches.length === 2) { /* 1-finger pan disabled */
-        const dx = e.touches[0].clientX - e.touches[1].clientX
-        const dy = e.touches[0].clientY - e.touches[1].clientY
-        const dist = Math.sqrt(dx * dx + dy * dy)
-        if (lastDist > 0) tf.current.s = Math.max(0.7, Math.min(3, tf.current.s * (dist / lastDist)))
-        lastDist = dist
+      e.preventDefault();
+      if (e.touches.length === 2) {
+        /* 1-finger pan disabled */
+        const dx = e.touches[0].clientX - e.touches[1].clientX;
+        const dy = e.touches[0].clientY - e.touches[1].clientY;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (lastDist > 0)
+          tf.current.s = Math.max(
+            0.7,
+            Math.min(3, tf.current.s * (dist / lastDist)),
+          );
+        lastDist = dist;
       }
-    }
+    };
     const onTE = (e: TouchEvent) => {
       if (e.touches.length === 0) {
-        const ch = e.changedTouches[0]
-        if (Math.abs(ch.clientX - drag.current.sx) < 10 && Math.abs(ch.clientY - drag.current.sy) < 10) {
-          const rect = c.getBoundingClientRect()
-          const sx = (ch.clientX - rect.left) * window.devicePixelRatio
-          const sy = (ch.clientY - rect.top) * window.devicePixelRatio
-          const w = toWorld(sx, sy)
-          onSelectNode(hitNode(w.x, w.y))
+        const ch = e.changedTouches[0];
+        if (
+          Math.abs(ch.clientX - drag.current.sx) < 10 &&
+          Math.abs(ch.clientY - drag.current.sy) < 10
+        ) {
+          const rect = c.getBoundingClientRect();
+          const sx = (ch.clientX - rect.left) * window.devicePixelRatio;
+          const sy = (ch.clientY - rect.top) * window.devicePixelRatio;
+          const w = toWorld(sx, sy);
+          onSelectNode(hitNode(w.x, w.y));
         }
-        drag.current.on = false
+        drag.current.on = false;
       }
-    }
+    };
 
-    c.addEventListener("mousedown", onMD)
-    window.addEventListener("mousemove", onMM)
-    window.addEventListener("mouseup", onMU)
-    c.addEventListener("wheel", onWh, { passive: false })
-    c.addEventListener("touchstart", onTS, { passive: false })
-    c.addEventListener("touchmove", onTM, { passive: false })
-    c.addEventListener("touchend", onTE)
+    c.addEventListener("mousedown", onMD);
+    window.addEventListener("mousemove", onMM);
+    window.addEventListener("mouseup", onMU);
+    c.addEventListener("wheel", onWh, { passive: false });
+    c.addEventListener("touchstart", onTS, { passive: false });
+    c.addEventListener("touchmove", onTM, { passive: false });
+    c.addEventListener("touchend", onTE);
 
     return () => {
-      c.removeEventListener("mousedown", onMD)
-      window.removeEventListener("mousemove", onMM)
-      window.removeEventListener("mouseup", onMU)
-      c.removeEventListener("wheel", onWh)
-      c.removeEventListener("touchstart", onTS)
-      c.removeEventListener("touchmove", onTM)
-      c.removeEventListener("touchend", onTE)
-    }
-  }, [onSelectNode, toWorld, hitNode])
+      c.removeEventListener("mousedown", onMD);
+      window.removeEventListener("mousemove", onMM);
+      window.removeEventListener("mouseup", onMU);
+      c.removeEventListener("wheel", onWh);
+      c.removeEventListener("touchstart", onTS);
+      c.removeEventListener("touchmove", onTM);
+      c.removeEventListener("touchend", onTE);
+    };
+  }, [onSelectNode, toWorld, hitNode]);
 
   return (
     <div ref={boxRef} className="absolute inset-0">
-      <canvas ref={canvasRef} className="block w-full h-full cursor-default" style={{ imageRendering: "pixelated" }} />
+      <canvas
+        ref={canvasRef}
+        className="block w-full h-full cursor-default"
+        style={{ imageRendering: "pixelated" }}
+      />
     </div>
-  )
+  );
 }

--- a/frontend/src/features/skill-tree/components/SkillTreeCanvas.tsx
+++ b/frontend/src/features/skill-tree/components/SkillTreeCanvas.tsx
@@ -62,7 +62,7 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
     if (!zoomAction) return
     const t = tf.current
     if (zoomAction.type === "in") t.s = Math.min(t.s * 1.25, 3)
-    else if (zoomAction.type === "out") t.s = Math.max(t.s / 1.25, 0.25)
+    else if (zoomAction.type === "out") t.s = Math.max(t.s / 1.25, 0.7)
     else { t.s = 0.7; t.x = 0; t.y = 0 }
   }, [zoomAction])
 
@@ -155,78 +155,65 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
       const trunkC = ["#5c3a1e", "#6b4226", "#7a4e30", "#6b4226", "#5c3a1e"]
       const hiC = "#8b6240"
 
-      // Main trunk: wide at base, narrow at top
-      for (let y = 600; y > -200; y -= PX) {
-        const prog = (600 - y) / 800
-        const w = 28 - prog * 18
-        const ci = Math.floor(((y + Math.floor(sway)) / (PX * 3)) % trunkC.length)
-        const xo = Math.sin(prog * 1.5) * 3 + sway
+      // Trunk: 地面(y=632) → Rootノード(y=400) まで。下が太く上（Root）が細い
+      const trunkTop = 400
+      const trunkBot = 632
+      const totalH = trunkBot - trunkTop   // 232px
+      for (let y = trunkBot; y >= trunkTop; y -= PX) {
+        const prog = (trunkBot - y) / totalH  // 0=地面（太い）, 1=Root（細い）
+        const w = Math.round(44 - prog * 32)  // 44px → 12px
+        const ci = Math.floor(((Math.abs(y) + Math.floor(sway)) / (PX * 3)) % trunkC.length)
+        const xo = Math.sin(prog * 2.0 + tick.current * 0.015) * prog * 3 + sway
         px(ctx, -w / 2 + xo, y, w, PX, trunkC[ci])
       }
-      // trunk highlight
-      for (let y = 580; y > -180; y -= PX) {
-        const prog = (580 - y) / 760
-        const xo = Math.sin(prog * 1.5) * 3 + sway
-        px(ctx, -2 + xo, y, PX, PX, hiC)
-      }
-
-      // Big branches to each Tier-1 category
-      const tier1 = SKILL_NODES.filter(n => n.tier === 1)
-      for (const nd of tier1) {
-        // main branch from trunk split point
-        const splitY = 380 - Math.abs(nd.x) * 0.15
-        const midX = nd.x * 0.35 + sway
-        const midY = (splitY + nd.y) / 2
-
-        pxLine(ctx, sway, splitY, midX, midY, "#5c3a1e", 3)
-        pxLine(ctx, midX, midY, nd.x, nd.y + 30, "#5c3a1e", 2)
-        // highlight
-        pxLine(ctx, sway + PX, splitY - PX, midX + PX, midY - PX, hiC, 1)
-
-        // Sub-branches to tier-2 children
-        for (const cid of nd.children) {
-          const ch = getNodeById(cid)
-          if (!ch) continue
-          const cmx = (nd.x + ch.x) / 2 + sway * 0.5
-          const cmy = (nd.y + ch.y) / 2
-          pxLine(ctx, nd.x, nd.y - 18, cmx, cmy, "#4a2e14", 2)
-          pxLine(ctx, cmx, cmy, ch.x, ch.y + 24, "#4a2e14", 1)
-        }
-      }
-
-      // Deeper tier branches
+      
+      // Generic connection loop for all nodes
       for (const nd of SKILL_NODES) {
-        if (nd.tier < 2) continue
         for (const cid of nd.children) {
           const ch = getNodeById(cid)
           if (!ch) continue
-          const cmx = (nd.x + ch.x) / 2
-          const cmy = (nd.y + ch.y) / 2
-          pxLine(ctx, nd.x, nd.y - 18, cmx, cmy, "#3d2210", 1)
-          pxLine(ctx, cmx, cmy, ch.x, ch.y + 24, "#3d2210", 1)
+
+          // Draw branches behind connections
+          pxLine(ctx, nd.x, nd.y - 20, ch.x, ch.y + 20, "#5c3a1e", 3)
         }
       }
     }
 
     /* ---- Pixel leaf clusters ---- */
     function drawLeaves(ctx: CanvasRenderingContext2D) {
+      // 下に末広がり: Root(y=400)が下部・Tier1(y=200)が最大幅→上へ小さくなる
       const clusters = [
-        { x: 0, y: -500, rx: 140, ry: 80 },
-        { x: -200, y: -420, rx: 120, ry: 70 },
-        { x: 200, y: -420, rx: 120, ry: 70 },
-        { x: -400, y: -300, rx: 100, ry: 60 },
-        { x: 400, y: -300, rx: 100, ry: 60 },
-        { x: -550, y: -150, rx: 90, ry: 55 },
-        { x: 550, y: -150, rx: 90, ry: 55 },
-        { x: -350, y: -100, rx: 80, ry: 50 },
-        { x: 350, y: -100, rx: 80, ry: 50 },
-        { x: -150, y: -200, rx: 90, ry: 55 },
-        { x: 150, y: -200, rx: 90, ry: 55 },
-        { x: 0, y: -320, rx: 100, ry: 65 },
-        { x: -600, y: 20, rx: 70, ry: 45 },
-        { x: 600, y: 20, rx: 70, ry: 45 },
-        { x: -700, y: -100, rx: 60, ry: 40 },
-        { x: 700, y: -100, rx: 60, ry: 40 },
+        // Root (y=400) - 幹の先端・エンジニアの種
+        { x: 0, y: 400, rx: 70, ry: 42 },
+
+        // Tier 1 (y=200) - span ±1100（最広）
+        { x: -1100, y: 200, rx: 118, ry: 64 },
+        { x:  -550, y: 200, rx: 110, ry: 60 },
+        { x:     0, y: 200, rx: 110, ry: 60 },
+        { x:   550, y: 200, rx: 110, ry: 60 },
+        { x:  1100, y: 200, rx: 118, ry: 64 },
+
+        // Tier 2 (y=0) - span ±900
+        { x: -900, y: 0, rx:  95, ry: 52 },
+        { x: -460, y: 0, rx:  90, ry: 50 },
+        { x:    0, y: 0, rx:  90, ry: 50 },
+        { x:  460, y: 0, rx:  90, ry: 50 },
+        { x:  900, y: 0, rx:  95, ry: 52 },
+
+        // Tier 3 (y=-200) - span ±700
+        { x: -700, y: -200, rx:  90, ry: 50 },
+        { x: -390, y: -200, rx:  86, ry: 48 },
+        { x:  -80, y: -200, rx:  86, ry: 48 },
+        { x:   80, y: -200, rx:  86, ry: 48 },
+        { x:  390, y: -200, rx:  86, ry: 48 },
+        { x:  700, y: -200, rx:  90, ry: 50 },
+
+        // Tier 4 (y=-400) - span ±400（最も狭い）
+        { x: -400, y: -400, rx:  78, ry: 44 },
+        { x: -200, y: -400, rx:  74, ry: 42 },
+        { x:    0, y: -400, rx:  74, ry: 42 },
+        { x:   200, y: -400, rx:  74, ry: 42 },
+        { x:   400, y: -400, rx:  78, ry: 44 },
       ]
       const greens = ["#1a4a1a", "#255a25", "#306830", "#1e5020", "#2a6a2a", "#3a7a3a"]
 
@@ -447,7 +434,7 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
       // Prevent default only if Ctrl key is pressed or using pinch gesture (generic heuristic)
       if (e.ctrlKey || e.metaKey) {
           e.preventDefault()
-          tf.current.s = Math.max(0.25, Math.min(3, tf.current.s * (e.deltaY > 0 ? 0.92 : 1.08)))
+          tf.current.s = Math.max(0.7, Math.min(3, tf.current.s * (e.deltaY > 0 ? 0.92 : 1.08)))
       }
     }
 
@@ -471,7 +458,7 @@ export function SkillTreeCanvas({ onSelectNode, selectedNode, zoomAction }: Prop
         const dx = e.touches[0].clientX - e.touches[1].clientX
         const dy = e.touches[0].clientY - e.touches[1].clientY
         const dist = Math.sqrt(dx * dx + dy * dy)
-        if (lastDist > 0) tf.current.s = Math.max(0.25, Math.min(3, tf.current.s * (dist / lastDist)))
+        if (lastDist > 0) tf.current.s = Math.max(0.7, Math.min(3, tf.current.s * (dist / lastDist)))
         lastDist = dist
       }
     }

--- a/frontend/src/features/skill-tree/components/ZoomControls.tsx
+++ b/frontend/src/features/skill-tree/components/ZoomControls.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+interface Props {
+  onZoomIn: () => void
+  onZoomOut: () => void
+  onReset: () => void
+}
+
+const btnStyle = {
+  background: "#1a1a2e",
+  border: "3px solid #e8b849",
+  color: "#e8b849",
+  boxShadow: "inset 1px 1px 0 #f5d97a, inset -1px -1px 0 #a67c20, 0 2px 0 #0a0a1a",
+  imageRendering: "pixelated" as const,
+}
+
+export function ZoomControls({ onZoomIn, onZoomOut, onReset }: Props) {
+  return (
+    <div className="absolute bottom-6 right-4 z-20 flex flex-col gap-2 font-sans">
+      <button
+        onClick={onZoomIn}
+        className="w-9 h-9 flex items-center justify-center text-base font-bold transition-transform active:translate-y-0.5"
+        style={btnStyle}
+        aria-label="Zoom in"
+      >
+        {"+"}
+      </button>
+      <button
+        onClick={onZoomOut}
+        className="w-9 h-9 flex items-center justify-center text-base font-bold transition-transform active:translate-y-0.5"
+        style={btnStyle}
+        aria-label="Zoom out"
+      >
+        {"-"}
+      </button>
+      <button
+        onClick={onReset}
+        className="w-9 h-9 flex items-center justify-center text-xs font-bold transition-transform active:translate-y-0.5"
+        style={btnStyle}
+        aria-label="Reset view"
+      >
+        {"R"}
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/features/skill-tree/types/data.ts
+++ b/frontend/src/features/skill-tree/types/data.ts
@@ -1,0 +1,348 @@
+export type NodeStatus = "completed" | "available" | "locked"
+export type SkillCategory = "web" | "ai" | "security" | "infra" | "design"
+
+export interface SkillNode {
+  id: string
+  label: string
+  category: SkillCategory
+  status: NodeStatus
+  x: number
+  y: number
+  tier: number
+  description: string
+  children: string[]
+}
+
+export interface RankInfo {
+  tier: number
+  nameJa: string
+  nameEn: string
+  level: "beginner" | "intermediate" | "master"
+}
+
+export const RANKS: RankInfo[] = [
+  { tier: 1, nameJa: "\u7A2E\u5B50", nameEn: "Seed", level: "beginner" },
+  { tier: 2, nameJa: "\u82D7\u6728", nameEn: "Sprout", level: "beginner" },
+  { tier: 3, nameJa: "\u82E5\u6728", nameEn: "Sapling", level: "beginner" },
+  { tier: 4, nameJa: "\u5DE8\u6728", nameEn: "Giant Tree", level: "intermediate" },
+  { tier: 5, nameJa: "\u6BCD\u6A39", nameEn: "Mother Tree", level: "intermediate" },
+  { tier: 6, nameJa: "\u6797", nameEn: "Grove", level: "intermediate" },
+  { tier: 7, nameJa: "\u68EE", nameEn: "Forest", level: "intermediate" },
+  { tier: 8, nameJa: "\u970A\u6A39", nameEn: "Spirit Tree", level: "master" },
+  { tier: 9, nameJa: "\u53E4\u6A39", nameEn: "Ancient Tree", level: "master" },
+  { tier: 10, nameJa: "\u4E16\u754C\u6A39", nameEn: "World Tree", level: "master" },
+]
+
+// Layout constants - wide fan-shaped tree
+// World coordinate: center = (0, 0), Y grows downward = deeper in the tree
+// Root at bottom, crown at top (negative Y)
+// const TIER_H = 200
+
+// 5 main branches, spread like a real tree crown
+// Web = far left, Design = far right, AI/Sec/Infra in between
+export const SKILL_NODES: SkillNode[] = [
+  // === ROOT ─ 幹の先端（下）：地面から伸びた幹の頂点・エンジニアの種 ===
+  {
+    id: "root",
+    label: "\u30A8\u30F3\u30B8\u30CB\u30A2\u306E\u6839",
+    category: "web",
+    status: "completed",
+    x: 0, y: 400,
+    tier: 0,
+    description: "\u5168\u3066\u306E\u30B9\u30AD\u30EB\u306E\u8D77\u70B9\u3002\u3053\u3053\u304B\u3089\u5192\u967A\u304C\u59CB\u307E\u308B\u3002",
+    children: ["web-basics", "ai-basics", "security-basics", "infra-basics", "design-basics"],
+  },
+
+  // === TIER 1 (y=200) ─ span ±1100 — Root直上・最大幅（下に末広がりの底辺）===
+  {
+    id: "web-basics",
+    label: "Web\u57FA\u790E",
+    category: "web", status: "completed",
+    x: -1100, y: 200,
+    tier: 1,
+    description: "HTML/CSS/JavaScript\u306E\u57FA\u672C\u3092\u7406\u89E3\u3059\u308B\u3002",
+    children: ["frontend", "backend"],
+  },
+  {
+    id: "ai-basics",
+    label: "AI\u57FA\u790E",
+    category: "ai", status: "completed",
+    x: -550, y: 200,
+    tier: 1,
+    description: "\u6A5F\u68B0\u5B66\u7FD2\u306E\u57FA\u672C\u6982\u5FF5\u3068Python\u306E\u57FA\u790E\u3002",
+    children: ["ml-intermediate", "llm-basics"],
+  },
+  {
+    id: "security-basics",
+    label: "\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3\u57FA\u790E",
+    category: "security", status: "available",
+    x: 0, y: 200,
+    tier: 1,
+    description: "\u60C5\u5831\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3\u306E\u57FA\u672C\u539F\u5247\u3068\u8105\u5A01\u30E2\u30C7\u30EB\u306E\u7406\u89E3\u3002",
+    children: ["web-security", "network-security"],
+  },
+  {
+    id: "infra-basics",
+    label: "\u30A4\u30F3\u30D5\u30E9\u57FA\u790E",
+    category: "infra", status: "available",
+    x: 550, y: 200,
+    tier: 1,
+    description: "Linux, \u30CD\u30C3\u30C8\u30EF\u30FC\u30AF, \u30B5\u30FC\u30D0\u30FC\u306E\u57FA\u790E\u77E5\u8B58\u3002",
+    children: ["cloud-basics", "container-basics"],
+  },
+  {
+    id: "design-basics",
+    label: "\u30C7\u30B6\u30A4\u30F3\u57FA\u790E",
+    category: "design", status: "available",
+    x: 1100, y: 200,
+    tier: 1,
+    description: "UI/UX\u30C7\u30B6\u30A4\u30F3\u306E\u57FA\u672C\u539F\u5247\u3068\u30C4\u30FC\u30EB\u3002",
+    children: ["ui-design", "ux-research"],
+  },
+
+  // === TIER 2 (y=0) ─ span ±900 ===
+  {
+    id: "frontend",
+    label: "\u30D5\u30ED\u30F3\u30C8\u30A8\u30F3\u30C9",
+    category: "web", status: "completed",
+    x: -900, y: 0,
+    tier: 2,
+    description: "React/Next.js\u3092\u4F7F\u3063\u305F\u30E2\u30C0\u30F3\u30D5\u30ED\u30F3\u30C8\u30A8\u30F3\u30C9\u958B\u767A\u3002",
+    children: ["react-advanced", "performance"],
+  },
+  {
+    id: "backend",
+    label: "\u30D0\u30C3\u30AF\u30A8\u30F3\u30C9",
+    category: "web", status: "available",
+    x: -680, y: 0,
+    tier: 2,
+    description: "Node.js/API\u8A2D\u8A08/\u30C7\u30FC\u30BF\u30D9\u30FC\u30B9\u306E\u57FA\u790E\u3002",
+    children: ["api-design", "database"],
+  },
+  {
+    id: "ml-intermediate",
+    label: "\u6A5F\u68B0\u5B66\u7FD2\u5FDC\u7528",
+    category: "ai", status: "available",
+    x: -460, y: 0,
+    tier: 2,
+    description: "\u6559\u5E2B\u3042\u308A/\u306A\u3057\u5B66\u7FD2\u3001\u30E2\u30C7\u30EB\u8A55\u4FA1\u306E\u4E2D\u7D1A\u30B9\u30AD\u30EB\u3002",
+    children: ["deep-learning"],
+  },
+  {
+    id: "llm-basics",
+    label: "LLM\u57FA\u790E",
+    category: "ai", status: "available",
+    x: -230, y: 0,
+    tier: 2,
+    description: "\u5927\u898F\u6A21\u8A00\u8A9E\u30E2\u30C7\u30EB\u306E\u4ED5\u7D44\u307F\u3068\u30D7\u30ED\u30F3\u30D7\u30C8\u30A8\u30F3\u30B8\u30CB\u30A2\u30EA\u30F3\u30B0\u3002",
+    children: ["llm-app"],
+  },
+  {
+    id: "web-security",
+    label: "Web\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3",
+    category: "security", status: "locked",
+    x: -80, y: 0,
+    tier: 2,
+    description: "XSS, CSRF, SQL\u30A4\u30F3\u30B8\u30A7\u30AF\u30B7\u30E7\u30F3\u306A\u3069\u306E\u5BFE\u7B56\u3002",
+    children: ["pentest"],
+  },
+  {
+    id: "network-security",
+    label: "\u30CD\u30C3\u30C8\u30EF\u30FC\u30AF\u9632\u5FA1",
+    category: "security", status: "locked",
+    x: 80, y: 0,
+    tier: 2,
+    description: "\u30D5\u30A1\u30A4\u30A2\u30A6\u30A9\u30FC\u30EB\u3001IDS/IPS\u3001VPN\u8A2D\u5B9A\u3002",
+    children: ["pentest"],
+  },
+  {
+    id: "cloud-basics",
+    label: "\u30AF\u30E9\u30A6\u30C9\u57FA\u790E",
+    category: "infra", status: "locked",
+    x: 300, y: 0,
+    tier: 2,
+    description: "AWS/GCP/Azure\u306E\u57FA\u672C\u30B5\u30FC\u30D3\u30B9\u306E\u7406\u89E3\u3002",
+    children: ["cloud-advanced"],
+  },
+  {
+    id: "container-basics",
+    label: "\u30B3\u30F3\u30C6\u30CA\u57FA\u790E",
+    category: "infra", status: "locked",
+    x: 520, y: 0,
+    tier: 2,
+    description: "Docker/\u30B3\u30F3\u30C6\u30CA\u306E\u57FA\u672C\u6982\u5FF5\u3068\u904B\u7528\u3002",
+    children: ["k8s"],
+  },
+  {
+    id: "ui-design",
+    label: "UI\u30C7\u30B6\u30A4\u30F3",
+    category: "design", status: "locked",
+    x: 700, y: 0,
+    tier: 2,
+    description: "Figma\u3092\u4F7F\u3063\u305FUI\u30B3\u30F3\u30DD\u30FC\u30CD\u30F3\u30C8\u8A2D\u8A08\u3002",
+    children: ["design-system"],
+  },
+  {
+    id: "ux-research",
+    label: "UX\u30EA\u30B5\u30FC\u30C1",
+    category: "design", status: "locked",
+    x: 900, y: 0,
+    tier: 2,
+    description: "\u30E6\u30FC\u30B6\u30FC\u30A4\u30F3\u30BF\u30D3\u30E5\u30FC\u3068\u30E6\u30FC\u30B6\u30D3\u30EA\u30C6\u30A3\u30C6\u30B9\u30C8\u3002",
+    children: ["design-system"],
+  },
+
+  // === TIER 3 (y=-200) ─ span ±700（上に向かって狭まる）===
+  {
+    id: "react-advanced",
+    label: "React\u4E0A\u7D1A",
+    category: "web", status: "available",
+    x: -700, y: -200,
+    tier: 3,
+    description: "Server Components, Suspense, \u30D1\u30D5\u30A9\u30FC\u30DE\u30F3\u30B9\u6700\u9069\u5316\u3002",
+    children: ["fullstack"],
+  },
+  {
+    id: "performance",
+    label: "\u30D1\u30D5\u30A9\u30FC\u30DE\u30F3\u30B9",
+    category: "web", status: "locked",
+    x: -545, y: -200,
+    tier: 3,
+    description: "Core Web Vitals\u6700\u9069\u5316\u3068\u30D0\u30F3\u30C9\u30EB\u5206\u6790\u3002",
+    children: ["fullstack"],
+  },
+  {
+    id: "api-design",
+    label: "API\u8A2D\u8A08",
+    category: "web", status: "locked",
+    x: -390, y: -200,
+    tier: 3,
+    description: "RESTful API / GraphQL\u8A2D\u8A08\u30D1\u30BF\u30FC\u30F3\u3002",
+    children: ["fullstack"],
+  },
+  {
+    id: "database",
+    label: "\u30C7\u30FC\u30BF\u30D9\u30FC\u30B9",
+    category: "web", status: "locked",
+    x: -230, y: -200,
+    tier: 3,
+    description: "RDB\u8A2D\u8A08\u3001\u30A4\u30F3\u30C7\u30C3\u30AF\u30B9\u3001\u30AF\u30A8\u30EA\u6700\u9069\u5316\u3002",
+    children: ["fullstack"],
+  },
+  {
+    id: "deep-learning",
+    label: "\u6DF1\u5C64\u5B66\u7FD2",
+    category: "ai", status: "locked",
+    x: -80, y: -200,
+    tier: 3,
+    description: "CNN, RNN, Transformer\u30A2\u30FC\u30AD\u30C6\u30AF\u30C1\u30E3\u306E\u7406\u89E3\u3002",
+    children: ["ai-engineering"],
+  },
+  {
+    id: "llm-app",
+    label: "LLM\u30A2\u30D7\u30EA\u958B\u767A",
+    category: "ai", status: "locked",
+    x: 80, y: -200,
+    tier: 3,
+    description: "RAG, Agent, Fine-tuning\u3092\u6D3B\u7528\u3057\u305FLLM\u30A2\u30D7\u30EA\u69CB\u7BC9\u3002",
+    children: ["ai-engineering"],
+  },
+  {
+    id: "pentest",
+    label: "\u30DA\u30CD\u30C8\u30EC\u30FC\u30B7\u30E7\u30F3",
+    category: "security", status: "locked",
+    x: 230, y: -200,
+    tier: 3,
+    description: "\u8106\u5F31\u6027\u8A3A\u65AD\u3068\u30DA\u30CD\u30C8\u30EC\u30FC\u30B7\u30E7\u30F3\u30C6\u30B9\u30C8\u624B\u6CD5\u3002",
+    children: ["security-arch"],
+  },
+  {
+    id: "cloud-advanced",
+    label: "\u30AF\u30E9\u30A6\u30C9\u5FDC\u7528",
+    category: "infra", status: "locked",
+    x: 390, y: -200,
+    tier: 3,
+    description: "\u30B5\u30FC\u30D0\u30FC\u30EC\u30B9\u3001IaC\u3001\u30DE\u30A4\u30AF\u30ED\u30B5\u30FC\u30D3\u30B9\u30A2\u30FC\u30AD\u30C6\u30AF\u30C1\u30E3\u3002",
+    children: ["sre"],
+  },
+  {
+    id: "k8s",
+    label: "Kubernetes",
+    category: "infra", status: "locked",
+    x: 545, y: -200,
+    tier: 3,
+    description: "Kubernetes\u30AF\u30E9\u30B9\u30BF\u7BA1\u7406\u3068\u30AA\u30FC\u30B1\u30B9\u30C8\u30EC\u30FC\u30B7\u30E7\u30F3\u3002",
+    children: ["sre"],
+  },
+  {
+    id: "design-system",
+    label: "\u30C7\u30B6\u30A4\u30F3\u30B7\u30B9\u30C6\u30E0",
+    category: "design", status: "locked",
+    x: 700, y: -200,
+    tier: 3,
+    description: "\u30B9\u30B1\u30FC\u30E9\u30D6\u30EB\u306A\u30C7\u30B6\u30A4\u30F3\u30B7\u30B9\u30C6\u30E0\u306E\u69CB\u7BC9\u3068\u904B\u7528\u3002",
+    children: ["creative-tech"],
+  },
+
+  // === TIER 4 (y=-400) ─ span ±400（上に向かって最も狭い）===
+  {
+    id: "fullstack",
+    label: "\u30D5\u30EB\u30B9\u30BF\u30C3\u30AF",
+    category: "web", status: "locked",
+    x: -400, y: -400,
+    tier: 4,
+    description: "\u30D5\u30ED\u30F3\u30C8/\u30D0\u30C3\u30AF/DB\u5168\u3066\u3092\u7D71\u5408\u3057\u305F\u958B\u767A\u529B\u3002",
+    children: ["architect"],
+  },
+  {
+    id: "ai-engineering",
+    label: "AI\u30A8\u30F3\u30B8\u30CB\u30A2\u30EA\u30F3\u30B0",
+    category: "ai", status: "locked",
+    x: -200, y: -400,
+    tier: 4,
+    description: "AI/ML\u30B7\u30B9\u30C6\u30E0\u306E\u8A2D\u8A08\u304B\u3089\u672C\u756A\u904B\u7528\u307E\u3067\u3002",
+    children: ["architect"],
+  },
+  {
+    id: "security-arch",
+    label: "\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3\u8A2D\u8A08",
+    category: "security", status: "locked",
+    x: 0, y: -400,
+    tier: 4,
+    description: "\u30BC\u30ED\u30C8\u30E9\u30B9\u30C8\u3001\u8105\u5A01\u30E2\u30C7\u30EA\u30F3\u30B0\u3001\u30BB\u30AD\u30E5\u30EA\u30C6\u30A3\u30A2\u30FC\u30AD\u30C6\u30AF\u30C1\u30E3\u3002",
+    children: ["architect"],
+  },
+  {
+    id: "sre",
+    label: "SRE",
+    category: "infra", status: "locked",
+    x: 200, y: -400,
+    tier: 4,
+    description: "\u4FE1\u983C\u6027\u30A8\u30F3\u30B8\u30CB\u30A2\u30EA\u30F3\u30B0\u3001\u76E3\u8996\u3001\u30A4\u30F3\u30B7\u30C7\u30F3\u30C8\u5BFE\u5FDC\u3002",
+    children: ["architect"],
+  },
+  {
+    id: "creative-tech",
+    label: "\u30AF\u30EA\u30A8\u30A4\u30C6\u30A3\u30D6\u6280\u8853",
+    category: "design", status: "locked",
+    x: 400, y: -400,
+    tier: 4,
+    description: "3D\u3001\u30A2\u30CB\u30E1\u30FC\u30B7\u30E7\u30F3\u3001\u30A4\u30F3\u30BF\u30E9\u30AF\u30C6\u30A3\u30D6\u30A2\u30FC\u30C8\u3002",
+    children: ["architect"],
+  },
+
+  // === TIER 5 ─ 樹冠（最上点・末広がりの頂点）===
+  {
+    id: "architect",
+    label: "\u4E16\u754C\u6A39\u306E\u30A2\u30FC\u30AD\u30C6\u30AF\u30C8",
+    category: "ai", status: "locked",
+    x: 0, y: -560,
+    tier: 5,
+    description: "\u5168\u9818\u57DF\u3092\u7D71\u5408\u3057\u3001\u6280\u8853\u306E\u9802\u70B9\u306B\u7ACB\u3064\u5B58\u5728\u3002\u4E16\u754C\u6A39\u306E\u5B88\u8B77\u8005\u3002",
+    children: [],
+  },
+]
+
+export function getNodeById(id: string): SkillNode | undefined {
+  return SKILL_NODES.find((n) => n.id === id)
+}


### PR DESCRIPTION
## 実装の概要

スキルツリーのノード配置・見た目を複数改善した。

- ノード配置を「下に末広がり・エンジニアの種(Root)を下部」に変更
  - Root (y=+400・最下部)、Tier1 (y=+200・幅±1100・最大幅)、Tier2 (y=0・幅±900)、Tier3 (y=-200・幅±700)、Tier4 (y=-400・幅±400)
- ドラッグによるパン移動を無効化（クリック選択・ズームは維持）
- ノードラベルのフォントサイズを拡大 (13px → 21px)
- カテゴリカラーの縁取りを太く (PX×1 → PX×3 相当)
- ダッシュボードの「SKILL TREE」タイトルを大きく (text-base → text-2xl)
- 「ドラッグで移動」の説明文を削除

## 🔧 技術的な意思決定とトレードオフ (最重要)

### 採用したアプローチ

- **手法**: HTML5 Canvas のワールド座標でノードのYを反転し、幅をTierごとに変化させることで末広がりを実現
- **メリット**: 「木の根が地面にある」という自然なメタファーと一致し、視覚的な階層が分かりやすい
- **デメリット/リスク**: Tier間のX座標スパンが大きく異なるため、接続線が斜めに急角度になる場合がある

### 却下したアプローチ（代替案）

- **手法**: Root上部・Tier4下部の「上から下への末広がり」
- **却下理由**: ユーザーの要望が「種(Root)が下・枝が上に広がる」木の比喩と異なったため

## 🧪 テスト戦略と範囲

### 追加したテストケース

- [ ] 正常系: ページ表示・ノードクリックによる選択・ズーム操作
- [ ] 異常系: 特になし（座標変更のみ）
- [ ] **テストしていないこと**: 各ノードの接続線が重ならないかの網羅的確認

## セキュリティに関する自己評価

- [x] 機密情報のハードコードはないか
- [x] 入力値の検証（バリデーション）は行っているか（フロントのUI変更のみ）
- [x] 既知の脆弱性パターンへの対策は考慮したか（該当なし）

## レビュワー（人間）への申し送り事項

フロントエンドのCanvas描画ロジックとノード座標定義のみの変更です。バックエンドへの影響はありません。実際の表示確認を兼ねてレビューをお願いします。