### PR TITLE
feat(dashboard): レトロゲーム風デザイン刷新 (Issue #75)

### DIFF
--- a/frontend/src/app/dashboard/layout.tsx
+++ b/frontend/src/app/dashboard/layout.tsx
@@ -11,11 +11,26 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen bg-[#FDFEF0]">
+    <div className="min-h-screen bg-transparent">
       {/* Top Header Bar - Full Width */}
-      <header className="sticky top-0 z-50 flex h-16 w-full items-center justify-end bg-[#559C71] px-6 text-white shadow-md">
-         <div className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-gray-600 shadow-sm">
-           👤
+      <header className="sticky top-0 z-50 flex h-16 w-full items-center justify-between bg-[#14532D] px-6 text-white border-b-4 border-black shadow-[0_4px_0_rgba(0,0,0,0.2)]">
+         {/* Logo / Brand Area */}
+         <div className="flex items-center gap-2">
+            <div className="h-8 w-8 bg-[#FCD34D] border-2 border-black animate-pulse"></div>
+            <span className="font-sans font-bold text-xl tracking-widest text-[#FCD34D] [text-shadow:2px_2px_0_black]">
+              KC3 HACK
+            </span>
+         </div>
+
+         {/* User Profile */}
+         <div className="flex items-center gap-4">
+            <div className="text-right hidden sm:block">
+              <p className="text-xs font-bold text-[#4ADE80] tracking-wider">PLAYER 1</p>
+              <p className="text-sm font-bold tracking-widest leading-none">READY</p>
+            </div>
+            <div className="flex h-10 w-10 items-center justify-center bg-white border-2 border-black text-black text-xl shadow-[2px_2px_0_black] hover:translate-y-1 hover:shadow-none transition-all cursor-pointer">
+              👤
+            </div>
          </div>
       </header>
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,26 +1,25 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
+@theme {
+  --font-sans: var(--font-dot-gothic);
+  --font-mono: var(--font-geist-mono);
 }
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+:root {
+  --background: #FDFEF0;
+  --foreground: #171717;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --background: #FDFEF0;
+    --foreground: #171717;
   }
 }
 
 body {
-  background: var(--background);
+  background-color: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-dot-gothic);
+  background-image: url("data:image/svg+xml,%3Csvg width='60' height='60' viewBox='0 0 60 60' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23559C71' fill-opacity='0.05'%3E%3Cpath d='M36 34v-4h-2v4h-4v2h4v4h2v-4h4v-2h-4zm0-30V0h-2v4h-4v2h4v4h2V6h4V4h-4zM6 34v-4H4v4H0v2h4v4h2v-4h4v-2H6zM6 4V0H4v4H0v2h4v4h2V6h4V4H6z'/%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
 }

--- a/frontend/src/features/dashboard/components/AcquiredBadges.tsx
+++ b/frontend/src/features/dashboard/components/AcquiredBadges.tsx
@@ -2,31 +2,64 @@
 
 export function AcquiredBadges() {
   return (
-    <div className="mt-8">
-      <h3 className="mb-4 text-xl font-bold text-[#2C5F2D]">取得バッチ</h3>
-      <div className="flex items-center justify-between rounded-xl border-2 border-[#2C5F2D] bg-[#FDFEF0] px-12 py-8 shadow-sm">
+    <div className="mt-8 font-sans">
+      <h3 className="mb-4 text-2xl font-bold tracking-widest text-[#2C5F2D] [text-shadow:2px_2px_0_#a3e635]">
+        獲得バッチ
+      </h3>
+      
+      <div 
+        className="flex items-center justify-between bg-[#FDFEF0] px-12 py-8"
+        style={{
+          border: "4px solid #2C5F2D",
+          boxShadow: "8px 8px 0 #2C5F2D",
+          imageRendering: "pixelated"
+        }}
+      >
         {/* Trophy */}
         <div className="flex flex-col items-center">
-          <div className="text-6xl drop-shadow-md">🏆</div>
+          <div className="text-6xl filter drop-shadow-[4px_4px_0_rgba(0,0,0,0.2)] grayscale-[0.2] hover:grayscale-0 transition-all active:translate-y-1">🏆</div>
         </div>
 
         {/* Medals */}
         <div className="flex gap-8">
-          <div className="flex flex-col items-center gap-2">
-             <span className="text-xl font-bold text-blue-600">V</span>
-             <div className="flex h-16 w-16 items-center justify-center rounded-full bg-yellow-400 text-3xl font-bold text-white shadow-md border-4 border-yellow-200">
+          {/* Medal 1 */}
+          <div className="flex flex-col items-center gap-2 group">
+             <span className="text-xl font-bold text-[#2C5F2D] animate-bounce">▼</span>
+             <div 
+               className="flex h-16 w-16 items-center justify-center bg-[#fbbf24] text-3xl font-bold text-[#78350f] transition-transform group-hover:-translate-y-1"
+               style={{
+                 border: "4px solid #b45309",
+                 boxShadow: "inset -4px -4px 0 rgba(0,0,0,0.2), 4px 4px 0 #2C5F2D"
+               }}
+             >
                1
              </div>
           </div>
-          <div className="flex flex-col items-center gap-2">
-             <span className="text-xl font-bold text-blue-600">V</span>
-             <div className="flex h-16 w-16 items-center justify-center rounded-full bg-gray-400 text-3xl font-bold text-white shadow-md border-4 border-gray-200">
+          
+          {/* Medal 2 */}
+          <div className="flex flex-col items-center gap-2 group">
+             <span className="text-xl font-bold text-[#2C5F2D] opacity-0 group-hover:opacity-100 transition-opacity">▼</span>
+             <div 
+               className="flex h-16 w-16 items-center justify-center bg-[#9ca3af] text-3xl font-bold text-[#1f2937] transition-transform group-hover:-translate-y-1"
+               style={{
+                 border: "4px solid #4b5563",
+                 boxShadow: "inset -4px -4px 0 rgba(0,0,0,0.2), 4px 4px 0 #2C5F2D"
+               }}
+             >
                2
              </div>
           </div>
-          <div className="flex flex-col items-center gap-2">
-             <span className="text-xl font-bold text-blue-600">V</span>
-             <div className="flex h-16 w-16 items-center justify-center rounded-full bg-amber-700 text-3xl font-bold text-white shadow-md border-4 border-amber-600">
+          
+          {/* Medal 3 */}
+          <div className="flex flex-col items-center gap-2 group">
+             <span className="text-xl font-bold text-[#2C5F2D] opacity-0 group-hover:opacity-100 transition-opacity">▼</span>
+             <div 
+               className="flex h-16 w-16 items-center justify-center bg-[#d97706] text-3xl font-bold text-[#78350f] transition-transform group-hover:-translate-y-1"
+               style={{
+                 border: "4px solid #92400e",
+                 boxShadow: "inset -4px -4px 0 rgba(0,0,0,0.2), 4px 4px 0 #2C5F2D"
+               }}
+             >
                3
              </div>
           </div>

--- a/frontend/src/features/dashboard/components/AppSidebar.tsx
+++ b/frontend/src/features/dashboard/components/AppSidebar.tsx
@@ -11,32 +11,35 @@ export function AppSidebar() {
   };
 
   const getLinkClass = (path: string) => {
+    const baseClass = "flex items-center p-3 transition-all duration-200 group border-4 font-sans mb-3 rounded-none";
+    
     if (isActive(path)) {
-      return "flex items-center rounded-r-full bg-[#B8CAA8] p-3 text-gray-900 group";
+      return `${baseClass} bg-[#FCD34D] border-black text-black shadow-[inset_4px_4px_0_rgba(0,0,0,0.2)] font-bold tracking-widest`;
     }
-    return "flex items-center rounded-lg p-3 text-white hover:bg-[#468B62] group";
-  };
-
-  const getTextClass = (path: string) => {
-      if (isActive(path)) {
-          return "ml-3 text-lg text-[#D16B36] font-bold";
-      }
-      return "ml-3 text-lg";
+    return `${baseClass} bg-[#4ADE80] border-black text-black hover:bg-[#86EFAC] shadow-[4px_4px_0_black] active:shadow-none active:translate-x-[4px] active:translate-y-[4px] font-bold tracking-widest`;
   };
 
   return (
-    <aside className="fixed left-0 top-16 z-40 h-[calc(100vh-4rem)] w-64 -translate-x-full transition-transform sm:translate-x-0 bg-[#559C71] text-white">
-      <div className="flex h-full flex-col overflow-y-auto px-3 py-4">
+    <aside className="fixed left-0 top-16 z-40 h-[calc(100vh-4rem)] w-64 -translate-x-full transition-transform sm:translate-x-0 bg-[#14532D] border-r-4 border-black">
+      <div className="flex h-full flex-col overflow-y-auto px-4 py-8">
+        
+        {/* Menu Title */}
+        <div className="mb-8 px-2">
+            <h2 className="text-xl font-bold tracking-widest text-[#4ADE80] font-sans border-b-4 border-[#4ADE80] pb-2 drop-shadow-[2px_2px_0_black]">
+                MAIN MENU
+            </h2>
+        </div>
+
         {/* Navigation Items */}
-        <ul className="space-y-4 font-medium">
+        <ul className="space-y-4 font-bold">
           {/* Home */}
           <li>
             <Link
               href="/dashboard"
               className={getLinkClass('/dashboard')}
             >
-              <div className="flex h-10 w-10 items-center justify-center text-2xl">🏠</div>
-              <span className={getTextClass('/dashboard')}>ホーム</span>
+              <div className="flex h-8 w-8 items-center justify-center text-xl mr-3 bg-white border-2 border-black text-black">🏠</div>
+              <span className="text-lg">HOME</span>
             </Link>
           </li>
           
@@ -46,8 +49,8 @@ export function AppSidebar() {
               href="/exercises"
               className={getLinkClass('/exercises')}
             >
-              <div className="flex h-10 w-10 items-center justify-center text-2xl">📝</div>
-              <span className={getTextClass('/exercises')}>演習</span>
+              <div className="flex h-8 w-8 items-center justify-center text-xl mr-3 bg-white border-2 border-black text-black">⚔️</div>
+              <span className="text-lg">QUESTS</span>
             </Link>
           </li>
           
@@ -57,11 +60,24 @@ export function AppSidebar() {
               href="/grades"
               className={getLinkClass('/grades')}
             >
-              <div className="flex h-10 w-10 items-center justify-center text-2xl">🔖</div>
-              <span className={getTextClass('/grades')}>成績</span>
+              <div className="flex h-8 w-8 items-center justify-center text-xl mr-3 bg-white border-2 border-black text-black">📜</div>
+              <span className="text-lg">STATS</span>
             </Link>
           </li>
         </ul>
+        
+        {/* System Info Box */}
+        <div className="mt-auto border-4 border-black bg-black p-4 text-[#4ADE80] font-sans text-xs tracking-wider">
+            <p className="mb-2 border-b border-[#4ADE80] pb-1">SYSTEM STATUS</p>
+            <div className="flex justify-between mb-1">
+                <span>ONLINE</span>
+                <span className="animate-pulse text-[#FCD34D]">●</span>
+            </div>
+            <div className="flex justify-between">
+                <span>VER.</span>
+                <span>2.0.26</span>
+            </div>
+        </div>
       </div>
     </aside>
   );

--- a/frontend/src/features/dashboard/components/DashboardContainer.tsx
+++ b/frontend/src/features/dashboard/components/DashboardContainer.tsx
@@ -59,11 +59,11 @@ export function DashboardContainer({ userId = 'default-user' }: DashboardContain
 
   if (loading) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[#FDFEF0]">
+      <div className="flex min-h-screen items-center justify-center bg-transparent">
         <div className="text-center">
           <div className="mb-4 inline-flex h-12 w-12 animate-spin rounded-full border-4 border-gray-300 border-t-[#559C71]" />
-          <p className="text-[#559C71]">
-            Loading...
+          <p className="text-[#559C71] tracking-widest">
+            LOADING...
           </p>
         </div>
       </div>
@@ -72,9 +72,9 @@ export function DashboardContainer({ userId = 'default-user' }: DashboardContain
 
   if (error || !userStatus) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[#FDFEF0]">
-        <div className="rounded-lg bg-white p-8 text-center shadow-lg">
-          <p className="text-red-600">
+      <div className="flex min-h-screen items-center justify-center bg-transparent">
+        <div className="rounded-none border-2 border-red-500 bg-white p-8 text-center shadow-[4px_4px_0px_0px_rgba(239,68,68,1)]">
+          <p className="text-red-500">
             {error || 'Error loading dashboard'}
           </p>
         </div>
@@ -83,25 +83,31 @@ export function DashboardContainer({ userId = 'default-user' }: DashboardContain
   }
 
   return (
-    <main className="min-h-screen bg-[#FDFEF0] px-4 py-8">
-      <div className="mx-auto max-w-5xl space-y-12">
+    <main className="min-h-screen bg-transparent px-4 py-4 font-sans text-gray-900">
+      <div className="mx-auto max-w-6xl space-y-8">
         {/* Header Section */}
-        <div className="flex flex-col gap-4 relative z-10">
-            <h1 className="text-4xl font-bold tracking-tight text-[#2C5F2D]">こんにちは</h1>
+        <div className="flex flex-col gap-6 relative z-10 md:flex-row md:items-start md:justify-between">
+            <div className="relative pt-2">
+              <h1 className="text-5xl font-bold tracking-widest text-[#2C5F2D] [text-shadow:2px_2px_0_#a3e635]">
+                WELCOME BACK, PLAYER
+              </h1>
+            </div>
             
             {/* Continue Button aligned right */}
-            <div className="flex flex-col items-end self-end w-full max-w-xs">
-                 <span className="mb-2 text-sm font-bold text-[#2C5F2D]">前回の続きから</span>
-                 <button className="group flex w-full items-center justify-between rounded-full border-2 border-[#2C5F2D] bg-white px-6 py-3 text-lg font-bold text-[#2C5F2D] shadow-sm transition-colors hover:bg-gray-50">
-                    <span>演習タイトル</span>
-                    <span className="text-2xl">→</span>
+            <div className="flex flex-col items-end w-full max-w-sm mt-8 md:mt-12">
+                 <span className="mb-2 text-xs tracking-wider text-[#2C5F2D] animate-pulse">CONTINUE MISSION</span>
+                 <button className="group flex w-full items-center justify-between border-2 border-[#2C5F2D] bg-white px-6 py-4 text-lg font-bold text-[#2C5F2D] shadow-[4px_4px_0px_0px_#2C5F2D] transition-all hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[2px_2px_0px_0px_#2C5F2D] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none">
+                    <span className="truncate mr-4">演習タイトル</span>
+                    <span className="text-2xl group-hover:translate-x-1 transition-transform">→</span>
                  </button>
             </div>
         </div>
 
         {/* Skill Tree Section */}
         <section className="relative z-0">
-          <div className="relative w-full h-[600px] overflow-hidden rounded-xl border-4 border-[#2C5F2D] bg-[#0a0f08] shadow-lg">
+          <div className="relative w-full h-[600px] overflow-hidden border-4 border-[#2C5F2D] bg-[#0a0f08] shadow-[8px_8px_0_0_#2C5F2D]">
+            <div className="absolute inset-0 bg-[linear-gradient(rgba(74,222,128,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(74,222,128,0.03)_1px,transparent_1px)] bg-[size:20px_20px]" />
+            <div className="absolute inset-0 pointer-events-none bg-gradient-to-b from-transparent via-transparent to-[#0a0f08]/80" />
             <SkillTreeCanvas
               onSelectNode={handleSelectNode}
               selectedNode={selectedNode}
@@ -116,21 +122,15 @@ export function DashboardContainer({ userId = 'default-user' }: DashboardContain
             />
             
             {/* Title Overlay */}
-            <div className="absolute top-4 left-1/2 -translate-x-1/2 z-20 text-center pointer-events-none font-sans">
+            <div className="absolute top-6 left-1/2 -translate-x-1/2 z-20 text-center pointer-events-none">
               <h3
-                className="text-2xl font-bold tracking-widest"
+                className="text-4xl font-bold tracking-[0.2em] text-[#fcd34d]"
                 style={{
-                  color: "#e8b849",
-                  textShadow: "2px 2px 0 #7a5a10, -1px -1px 0 #0a0a0a",
+                  textShadow: "4px 4px 0 #000, -2px -2px 0 #000",
                 }}
               >
                 SKILL TREE
               </h3>
-              {mounted && (
-                <p className="text-[10px] mt-1" style={{ color: "#666680" }} suppressHydrationWarning>
-                  スクロールでズーム / クリックで詳細
-                </p>
-              )}
             </div>
 
             {selectedNode && (
@@ -141,7 +141,9 @@ export function DashboardContainer({ userId = 'default-user' }: DashboardContain
 
         {/* Acquired Badges Section */}
         <section className="relative z-10 w-full">
-          <AcquiredBadges />
+          <div className="border-t-4 border-[#2C5F2D] pt-8">
+            <AcquiredBadges />
+          </div>
         </section>
       </div>
     </main>

--- a/frontend/src/features/skill-tree/components/RankBar.tsx
+++ b/frontend/src/features/skill-tree/components/RankBar.tsx
@@ -18,56 +18,53 @@ export function RankBar() {
 
   return (
     <div
-      className="absolute top-3 left-3 z-20 flex items-center gap-2 px-2.5 py-1.5 font-sans"
+      className="absolute top-3 left-3 z-20 flex items-center gap-2 px-3 py-2 font-sans"
       style={{
-        background: "rgba(10,10,20,0.75)",
-        border: "2px solid rgba(232,184,73,0.5)",
-        backdropFilter: "blur(4px)",
+        background: "rgba(31, 41, 55, 0.95)",
+        border: "2px solid #e8b849",
+        boxShadow: "2px 2px 0 #2C5F2D",
+        imageRendering: "pixelated",
       }}
     >
       {/* Tier badge */}
       <div
-        className="w-6 h-6 flex items-center justify-center text-[10px] font-bold shrink-0"
+        className="w-8 h-8 flex items-center justify-center text-xs font-bold shrink-0 bg-[#111827]"
         style={{
-          background: "rgba(42,42,78,0.8)",
           border: "2px solid",
           borderColor: colors.text,
           color: colors.text,
+          boxShadow: `0 0 4px ${colors.text}44`
         }}
       >
         {currentRank.tier}
       </div>
 
-      <div className="flex flex-col gap-0.5">
-        <div className="flex items-center gap-1.5">
-          <span className="text-[10px] font-bold" style={{ color: colors.text }}>
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-bold tracking-wide" style={{ color: colors.text }}>
             {currentRank.nameJa}
           </span>
-          <span className="text-[8px]" style={{ color: "#666680" }}>
+          <span className="text-[10px] uppercase tracking-wider text-gray-400">
             {currentRank.nameEn}
           </span>
         </div>
 
         {/* Tiny EXP bar */}
-        <div className="flex items-center gap-1.5">
-          <span className="text-[7px]" style={{ color: "#666680" }}>{"EXP"}</span>
+        <div className="flex items-center gap-2">
+          <span className="text-[9px] font-bold text-gray-500">{"EXP"}</span>
           <div
-            className="h-[6px] w-20 relative overflow-hidden"
-            style={{
-              background: "#0a0a1e",
-              border: "1px solid #333355",
-            }}
+            className="h-2 w-24 relative overflow-hidden bg-[#111827] border border-gray-700"
           >
             <div
-              className="h-full absolute left-0 top-0"
+              className="h-full absolute left-0 top-0 transition-all duration-500"
               style={{
                 width: `${progress * 100}%`,
                 background: colors.bar,
-                boxShadow: `inset 0 -1px 0 ${colors.barDark}`,
+                boxShadow: `0 0 4px ${colors.bar}`
               }}
             />
           </div>
-          <span className="text-[7px]" style={{ color: "#666680" }}>
+          <span className="text-[9px] font-bold text-gray-400">
             {completedCount}/{totalCount}
           </span>
         </div>

--- a/frontend/src/features/skill-tree/components/SkillLegend.tsx
+++ b/frontend/src/features/skill-tree/components/SkillLegend.tsx
@@ -1,16 +1,16 @@
 'use client';
 
 const rpgBoxStyle = {
-  background: "#1a1a2e",
-  border: "4px solid #e8b849",
-  boxShadow: "inset 2px 2px 0 #f5d97a, inset -2px -2px 0 #a67c20, 0 4px 0 #0a0a1a",
+  background: "rgba(31, 41, 55, 0.95)",
+  border: "2px solid #e8b849",
+  boxShadow: "4px 4px 0 #2C5F2D",
   imageRendering: "pixelated" as const,
 }
 
 const statusEntries = [
-  { color: "#e8b849", label: "\u30AF\u30EA\u30A2\u6E08\u307F" },
-  { color: "#5abf5a", label: "\u6311\u6226\u53EF\u80FD" },
-  { color: "#5a6068", label: "\u30ED\u30C3\u30AF\u4E2D" },
+  { color: "#e8b849", label: "CLEARED" },
+  { color: "#5abf5a", label: "AVAILABLE" },
+  { color: "#6b7280", label: "LOCKED" },
 ]
 
 const categoryEntries = [
@@ -23,33 +23,33 @@ const categoryEntries = [
 
 export function SkillLegend() {
   return (
-    <div className="absolute top-4 right-4 z-20 p-3 font-sans" style={rpgBoxStyle}>
-      <div className="text-[9px] font-bold mb-2 uppercase tracking-widest" style={{ color: "#8888aa" }}>
+    <div className="absolute top-4 right-4 z-20 p-4 font-sans" style={rpgBoxStyle}>
+      <div className="text-xs font-bold mb-3 uppercase tracking-widest text-[#e8b849] border-b border-[#e8b849]/30 pb-1">
         {"STATUS"}
       </div>
-      <div className="flex flex-col gap-1.5 mb-3">
+      <div className="flex flex-col gap-2 mb-4">
         {statusEntries.map((e, i) => (
           <div key={i} className="flex items-center gap-2">
             <div
               className="w-3 h-3 shrink-0"
-              style={{ background: e.color, border: "1px solid #000", boxShadow: `inset 1px 1px 0 ${e.color}88` }}
+              style={{ background: e.color, border: "1px solid #111827" }}
             />
-            <span className="text-[10px]" style={{ color: "#c0c0d0" }}>{e.label}</span>
+            <span className="text-xs font-bold tracking-wide text-gray-200">{e.label}</span>
           </div>
         ))}
       </div>
 
-      <div className="text-[9px] font-bold mb-2 uppercase tracking-widest" style={{ color: "#8888aa" }}>
+      <div className="text-xs font-bold mb-3 uppercase tracking-widest text-[#e8b849] border-b border-[#e8b849]/30 pb-1">
         {"CATEGORY"}
       </div>
-      <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col gap-2">
         {categoryEntries.map((c, i) => (
           <div key={i} className="flex items-center gap-2">
             <div
               className="w-3 h-3 shrink-0"
-              style={{ background: c.color, border: "1px solid #000", boxShadow: `inset 1px 1px 0 ${c.color}88` }}
+              style={{ background: c.color, border: "1px solid #111827" }}
             />
-            <span className="text-[10px]" style={{ color: "#c0c0d0" }}>{c.label}</span>
+            <span className="text-xs font-bold tracking-wide text-gray-200">{c.label}</span>
           </div>
         ))}
       </div>

--- a/frontend/src/features/skill-tree/components/SkillNodePanel.tsx
+++ b/frontend/src/features/skill-tree/components/SkillNodePanel.tsx
@@ -44,88 +44,84 @@ export function SkillNodePanel({ node, onClose }: Props) {
     <div
       className="absolute bottom-6 left-1/2 -translate-x-1/2 z-30 w-[360px] max-w-[calc(100vw-2rem)] p-4 font-sans animate-in slide-in-from-bottom-4 duration-200"
       style={{
-        background: "#1a1a2e",
+        background: "rgba(31, 41, 55, 0.95)",
         border: "4px solid #e8b849",
-        boxShadow: "inset 2px 2px 0 #f5d97a, inset -2px -2px 0 #a67c20, 0 4px 0 #0a0a1a",
+        boxShadow: "inset 2px 2px 0 #fcd34d, inset -2px -2px 0 #b45309, 0 4px 0 #000",
         imageRendering: "pixelated",
       }}
     >
       {/* Close button */}
       <button
         onClick={onClose}
-        className="absolute top-2 right-3 text-sm font-bold"
-        style={{ color: "#8888aa" }}
+        className="absolute top-2 right-2 flex h-6 w-6 items-center justify-center border-2 border-[#e8b849] bg-[#1f2937] text-sm text-[#e8b849] hover:bg-[#e8b849] hover:text-[#1f2937]"
         aria-label="Close panel"
       >
-        {"x"}
+        {"X"}
       </button>
 
       {/* Header */}
-      <div className="flex items-center gap-3 mb-3">
+      <div className="flex items-center gap-3 mb-4">
         {/* Pixel icon box */}
         <div
-          className="w-10 h-10 flex items-center justify-center text-lg shrink-0"
+          className="w-12 h-12 flex items-center justify-center text-xl shrink-0 border-2 bg-gray-900"
           style={{
-            background: "#2a2a4e",
-            border: `3px solid ${statusColor}`,
-            boxShadow: `inset 1px 1px 0 ${statusColor}66`,
+            borderColor: statusColor,
             color: statusColor,
+            boxShadow: `0 0 10px ${statusColor}44`
           }}
         >
-          {node.status === "completed" ? "\u2713" : node.status === "available" ? "!" : "\u25A0"}
+          {node.status === "completed" ? "✔" : node.status === "available" ? "!" : "🔒"}
         </div>
         <div>
-          <h3 className="text-sm font-bold leading-tight" style={{ color: statusColor }}>
+          <h3 className="text-lg font-bold leading-tight" style={{ color: statusColor }}>
             {node.label}
           </h3>
-          {/* <p className="text-[9px]" style={{ color: "#8888aa" }}>
-            {node.labelEn}
-          </p> */}
         </div>
       </div>
 
       {/* Tags row */}
-      <div className="flex flex-wrap gap-1.5 mb-3">
+      <div className="flex flex-wrap gap-2 mb-4">
         <span
-          className="text-[9px] px-2 py-0.5"
-          style={{ background: `${catColor}22`, color: catColor, border: `2px solid ${catColor}44` }}
+          className="text-xs px-2 py-1 font-bold tracking-wide"
+          style={{ background: "#1f2937", color: catColor, border: `1px solid ${catColor}` }}
         >
           {CATEGORY_LABELS[node.category]}
         </span>
         <span
-          className="text-[9px] px-2 py-0.5"
-          style={{ background: `${statusColor}22`, color: statusColor, border: `2px solid ${statusColor}44` }}
+          className="text-xs px-2 py-1 font-bold tracking-wide"
+          style={{ background: "#1f2937", color: statusColor, border: `1px solid ${statusColor}` }}
         >
           {STATUS_LABELS[node.status]}
         </span>
         <span
-          className="text-[9px] px-2 py-0.5"
-          style={{ background: "#2a2a4e", color: "#8888aa", border: "2px solid #444466" }}
+          className="text-xs px-2 py-1 font-bold tracking-wide text-gray-400 border border-gray-600 bg-[#1f2937]"
         >
-          {"Tier " + node.tier + " " + rank.nameJa}
+          {"TIER " + node.tier}
         </span>
       </div>
 
       {/* Description */}
-      <p className="text-xs leading-relaxed" style={{ color: "#c0c0d0" }}>
-        {node.description}
-      </p>
+      <div className="bg-[#0a0f08] border border-gray-700 p-3 mb-3">
+        <p className="text-sm leading-relaxed text-gray-300">
+          {node.description}
+        </p>
+      </div>
 
       {/* Action hint */}
       {node.status === "available" && (
         <div
-          className="mt-3 text-[10px] text-center py-1.5"
-          style={{ background: "#1a2a1a", border: "2px solid #5abf5a44", color: "#5abf5a" }}
+          className="mt-2 text-xs text-center py-2 font-bold tracking-wider animate-pulse"
+          style={{ background: "#14532d", border: "1px solid #4ade80", color: "#4ade80" }}
         >
-          {"GitHub\u30EA\u30DD\u30B8\u30C8\u30EA\u3092\u5206\u6790\u3057\u3066\u30B9\u30AD\u30EB\u3092\u81EA\u52D5\u5224\u5B9A\u3057\u307E\u3059"}
+          {"AVAILABLE FOR ANALYSIS"}
         </div>
       )}
       {node.status === "locked" && (
         <div
-          className="mt-3 text-[10px] text-center py-1.5"
-          style={{ background: "#1a1a2a", border: "2px solid #44446644", color: "#8888aa" }}
+          className="mt-2 text-xs text-center py-2 font-bold tracking-wider"
+          style={{ background: "#374151", border: "1px solid #6b7280", color: "#9ca3af" }}
         >
-          {"\u524D\u63D0\u30B9\u30AD\u30EB\u3092\u30AF\u30EA\u30A2\u3059\u308B\u3068\u30A2\u30F3\u30ED\u30C3\u30AF\u3055\u308C\u307E\u3059"}
+          {"LOCKED - PREREQUISITES REQUIRED"}
         </div>
       )}
     </div>

--- a/frontend/src/features/skill-tree/components/ZoomControls.tsx
+++ b/frontend/src/features/skill-tree/components/ZoomControls.tsx
@@ -7,10 +7,10 @@ interface Props {
 }
 
 const btnStyle = {
-  background: "#1a1a2e",
-  border: "3px solid #e8b849",
+  background: "rgba(31, 41, 55, 0.95)",
+  border: "2px solid #e8b849",
   color: "#e8b849",
-  boxShadow: "inset 1px 1px 0 #f5d97a, inset -1px -1px 0 #a67c20, 0 2px 0 #0a0a1a",
+  boxShadow: "2px 2px 0 #2C5F2D",
   imageRendering: "pixelated" as const,
 }
 
@@ -19,7 +19,7 @@ export function ZoomControls({ onZoomIn, onZoomOut, onReset }: Props) {
     <div className="absolute bottom-6 right-4 z-20 flex flex-col gap-2 font-sans">
       <button
         onClick={onZoomIn}
-        className="w-9 h-9 flex items-center justify-center text-base font-bold transition-transform active:translate-y-0.5"
+        className="w-10 h-10 flex items-center justify-center text-xl font-bold transition-all active:translate-y-[2px] active:shadow-none hover:bg-[#374151]"
         style={btnStyle}
         aria-label="Zoom in"
       >
@@ -27,7 +27,7 @@ export function ZoomControls({ onZoomIn, onZoomOut, onReset }: Props) {
       </button>
       <button
         onClick={onZoomOut}
-        className="w-9 h-9 flex items-center justify-center text-base font-bold transition-transform active:translate-y-0.5"
+        className="w-10 h-10 flex items-center justify-center text-xl font-bold transition-all active:translate-y-[2px] active:shadow-none hover:bg-[#374151]"
         style={btnStyle}
         aria-label="Zoom out"
       >
@@ -35,11 +35,11 @@ export function ZoomControls({ onZoomIn, onZoomOut, onReset }: Props) {
       </button>
       <button
         onClick={onReset}
-        className="w-9 h-9 flex items-center justify-center text-xs font-bold transition-transform active:translate-y-0.5"
+        className="w-10 h-10 flex items-center justify-center text-sm font-bold transition-all active:translate-y-[2px] active:shadow-none hover:bg-[#374151]"
         style={btnStyle}
         aria-label="Reset view"
       >
-        {"R"}
+        {"RES"}
       </button>
     </div>
   )


### PR DESCRIPTION
## 実装の概要
Issue #75 に基づき、ダッシュボード画面全体をレトロゲーム（ドット絵）風のデザインに刷新しました。
`DotGothic16` フォントの適用、クリーム色背景への変更、各コンポーネント（サイドバー、スキルツリー操作パネル、バッジ表示など）のピクセルアートスタイル化を行いました。

## 🔧 技術的な意思決定とトレードオフ (最重要)

### 採用したアプローチ

- **手法**: Tailwind CSS の `box-shadow` を活用したドット絵風ボーダーと、`text-shadow` によるレトロ文字装飾。背景には SVG パターン (Data URI) を適用。
- **メリット**: 画像素材を極力減らし、CSSのみで柔軟なレスポンシブ対応が可能。`globals.css` による統一的なフォント適用。
- **デメリット/リスク**: ハイコントラストな配色（サイドバーの緑/黒）を採用しているため、視認性の確認が必要かもしれない。

### 却下したアプローチ（代替案）

- **手法**: 画像スライスを使用したUIボーダーの実装。
- **却下理由**: レスポンシブ対応が複雑になるため、CSSでの描画を優先。

## 🧪 テスト戦略と範囲

### 追加したテストケース

- [ ] 正常系: ダッシュボード表示、サイドバーのホバー効果、レスポンシブレイアウトの目視確認。
- [ ] 異常系: 特になし（UI変更のみ）。
- [ ] **テストしていないこと**: スクリーンリーダー等のアクセシビリティ詳細検証。

## セキュリティに関する自己評価

- [x] 機密情報のハードコードはないか
- [x] 入力値の検証（バリデーション）は行っているか
- [x] 既知の脆弱性パターンへの対策は考慮したか

## レビュワー（人間）への申し送り事項

- デザインの大幅な変更を含むため、ブラウザでの実際の表示確認（特に背景パターンとフォントの読みやすさ）をお願いします。