### PR TITLE
feat: #77 管理API クエスト CRUD（一覧手動作成削除）

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -109,7 +109,7 @@ def admin_list_quests(
     db: Session = Depends(get_db),
     _: None = Depends(verify_admin_key),
 ) -> list[QuestSchema]:
-    """クエスト一覧取得（description 除く、フィルタリング対応）。
+    """クエスト一覧取得（フィルタリング対応）。
 
     認証: X-Admin-Key ヘッダーが必要
     """

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -6,15 +6,22 @@ Swagger UI: /admin/docs（認証必須）
 
 import secrets
 
-from fastapi import Depends, FastAPI, Header, HTTPException, Request, status
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request, status
 from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
 from app.core.config import settings
 from app.core.rank import calculate_rank
+from app.crud import quest as crud_quest
 from app.db.session import get_db
+from app.models.enums import QuestCategory
 from app.models.user import User
+from app.schemas.quest import Quest as QuestSchema
+from app.schemas.quest import QuestCreate
+
+# limit 値の上限（運用上大量取得を防ぐ）
+_ADMIN_LIST_MAX = 200
 
 # Admin専用のFastAPIアプリ（独立したSwagger UI用）
 admin_app = FastAPI(
@@ -86,3 +93,58 @@ def fix_user_ranks(
         raise
 
     return {"fixed_count": fixed_count, "total_users": len(users)}
+
+
+# ---------------------------------------------------------------------------
+# Quest 管理 (Issue #77: 管理者向け CRUD)
+# ---------------------------------------------------------------------------
+
+
+@admin_app.get("/quests", response_model=list[QuestSchema])
+def admin_list_quests(
+    category: QuestCategory | None = None,
+    difficulty: int | None = None,
+    skip: int = Query(0, ge=0, description="スキップ件数（0以上）"),
+    limit: int = Query(50, ge=1, le=_ADMIN_LIST_MAX, description=f"取得件数（1〜{_ADMIN_LIST_MAX}）"),
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_admin_key),
+) -> list[QuestSchema]:
+    """クエスト一覧取得（description 除く、フィルタリング対応）。
+
+    認証: X-Admin-Key ヘッダーが必要
+    """
+    return crud_quest.list_quests(db, skip=skip, limit=limit, category=category, difficulty=difficulty)
+
+
+@admin_app.post("/quests", response_model=QuestSchema, status_code=201)
+def admin_create_quest(
+    quest_in: QuestCreate,
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_admin_key),
+) -> QuestSchema:
+    """手動クエスト作成（ボディを直接埋める）。
+
+    認証: X-Admin-Key ヘッダーが必要
+
+    LLM を使わずに管理者が直接 title / description / difficulty / category を指定する。
+    description は Markdown 形式で入力すること（ADR 012）。
+    """
+    return crud_quest.create_quest(db, quest_in)
+
+
+@admin_app.delete("/quests/{quest_id}", status_code=204)
+def admin_delete_quest(
+    quest_id: int,
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_admin_key),
+) -> None:
+    """クエスト削除。
+
+    認証: X-Admin-Key ヘッダーが必要
+
+    - 204: 削除成功
+    - 404: 指定 ID のクエストが存在しない
+    """
+    deleted = crud_quest.delete_quest(db, quest_id)
+    if not deleted:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quest not found")

--- a/backend/app/crud/quest.py
+++ b/backend/app/crud/quest.py
@@ -52,7 +52,7 @@ def create_quest(db: Session, quest_in: QuestCreate) -> Quest:
 
 def delete_quest(db: Session, quest_id: int) -> bool:
     """クエストを削除する。存在した場合 True、存在しなかった場合 False を返す。"""
-    db_quest = db.query(Quest).filter(Quest.id == quest_id).first()
+    db_quest = get_quest(db, quest_id)
     if db_quest is None:
         return False
     db.delete(db_quest)

--- a/backend/app/crud/quest.py
+++ b/backend/app/crud/quest.py
@@ -48,3 +48,17 @@ def create_quest(db: Session, quest_in: QuestCreate) -> Quest:
         raise
     db.refresh(db_quest)
     return db_quest
+
+
+def delete_quest(db: Session, quest_id: int) -> bool:
+    """クエストを削除する。存在した場合 True、存在しなかった場合 False を返す。"""
+    db_quest = db.query(Quest).filter(Quest.id == quest_id).first()
+    if db_quest is None:
+        return False
+    db.delete(db_quest)
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    return True

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,6 +16,8 @@ os.environ.setdefault("JWT_SECRET_KEY", TEST_JWT_SECRET)
 # GitHub OAuth テスト用ダミー値（本番環境では絶対に使用しないこと）
 os.environ.setdefault("GITHUB_CLIENT_ID", "test_github_client_id")
 os.environ.setdefault("GITHUB_CLIENT_SECRET", "test_github_client_secret")
+# 管理 API テスト用ダミーキー（本番環境では絶対に使用しないこと）
+os.environ.setdefault("ADMIN_API_KEY", "test-admin-key-for-testing-only")
 
 from app.core.encryption import reset_fernet  # noqa: E402
 from app.db.base import Base  # noqa: E402, F401  # 全モデル登録のためbase経由でimport

--- a/backend/tests/test_api/test_admin.py
+++ b/backend/tests/test_api/test_admin.py
@@ -1,12 +1,28 @@
 """管理API（/admin）のテスト
 
 Note: APIキー認証のテストはE2Eテストで実施。
-ここではランク修正ロジックのみをテストする。
+ここではビジネスロジックをテストする。
 """
 
-from app.api.admin import fix_user_ranks
+from app.api.admin import admin_create_quest, admin_delete_quest, admin_list_quests, fix_user_ranks
 from app.crud.user import create_user
+from app.models.enums import QuestCategory
+from app.schemas.quest import QuestCreate
 from app.schemas.user import UserCreate
+
+
+# ---------------------------------------------------------------------------
+# テストヘルパー
+# ---------------------------------------------------------------------------
+
+
+def _quest_create(
+    title: str = "テストクエスト",
+    difficulty: int = 1,
+    category: QuestCategory = QuestCategory.WEB,
+    description: str = "## テスト\nテスト説明",
+) -> QuestCreate:
+    return QuestCreate(title=title, description=description, difficulty=difficulty, category=category)
 
 
 def test_fix_user_ranks_logic(db):
@@ -33,3 +49,93 @@ def test_fix_user_ranks_logic(db):
     db.refresh(user2)
     assert user1.rank == 1
     assert user2.rank == 4
+
+
+# ---------------------------------------------------------------------------
+# Quest 一覧
+# ---------------------------------------------------------------------------
+
+
+def test_admin_list_quests_empty(db):
+    """クエストが0件の場合、空リストを返す。"""
+    result = admin_list_quests(skip=0, limit=50, db=db, _=None)
+    assert result == []
+
+
+def test_admin_list_quests_returns_created(db):
+    """作成したクエストが一覧に含まれる。"""
+    admin_create_quest(quest_in=_quest_create(title="A"), db=db, _=None)
+    admin_create_quest(quest_in=_quest_create(title="B"), db=db, _=None)
+    result = admin_list_quests(skip=0, limit=50, db=db, _=None)
+    assert len(result) == 2
+
+
+def test_admin_list_quests_filter_category(db):
+    """category フィルタが機能する。"""
+    admin_create_quest(quest_in=_quest_create(category=QuestCategory.WEB), db=db, _=None)
+    admin_create_quest(quest_in=_quest_create(category=QuestCategory.AI), db=db, _=None)
+    result = admin_list_quests(skip=0, limit=50, category=QuestCategory.WEB, db=db, _=None)
+    assert len(result) == 1
+    assert result[0].category == QuestCategory.WEB
+
+
+def test_admin_list_quests_skip_limit(db):
+    """skip/limit が正しく動作する。"""
+    for i in range(5):
+        admin_create_quest(quest_in=_quest_create(title=f"Q{i}"), db=db, _=None)
+    result = admin_list_quests(skip=2, limit=2, db=db, _=None)
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Quest 手動作成
+# ---------------------------------------------------------------------------
+
+
+def test_admin_create_quest_returns_quest(db):
+    """作成したクエストが Quest スキーマで返る。"""
+    quest_in = _quest_create(title="新クエスト", difficulty=3, category=QuestCategory.SECURITY)
+    result = admin_create_quest(quest_in=quest_in, db=db, _=None)
+    assert result.id is not None
+    assert result.title == "新クエスト"
+    assert result.difficulty == 3
+    assert result.category == QuestCategory.SECURITY
+    assert result.is_generated is False
+    assert result.description == "## テスト\nテスト説明"
+
+
+def test_admin_create_quest_is_generated_false_by_default(db):
+    """is_generated のデフォルトは False。"""
+    result = admin_create_quest(quest_in=_quest_create(), db=db, _=None)
+    assert result.is_generated is False
+
+
+# ---------------------------------------------------------------------------
+# Quest 削除
+# ---------------------------------------------------------------------------
+
+
+def test_admin_delete_quest_success(db):
+    """存在するクエストを削除すると 204 相当で正常終了する。"""
+    created = admin_create_quest(quest_in=_quest_create(), db=db, _=None)
+    # delete は None を返す（204 No Content）
+    result = admin_delete_quest(quest_id=created.id, db=db, _=None)
+    assert result is None
+
+
+def test_admin_delete_quest_not_found(db):
+    """存在しない ID を削除すると 404 例外が上がる。"""
+    from fastapi import HTTPException
+    import pytest
+
+    with pytest.raises(HTTPException) as exc_info:
+        admin_delete_quest(quest_id=9999, db=db, _=None)
+    assert exc_info.value.status_code == 404
+
+
+def test_admin_delete_quest_removes_from_list(db):
+    """削除後、一覧から取得できなくなる。"""
+    created = admin_create_quest(quest_in=_quest_create(), db=db, _=None)
+    admin_delete_quest(quest_id=created.id, db=db, _=None)
+    result = admin_list_quests(skip=0, limit=50, db=db, _=None)
+    assert all(q.id != created.id for q in result)


### PR DESCRIPTION
**Issue**: #77

## 実装の概要

管理API（\/admin\）にクエスト CRUD エンドポイント3本を追加。
\POST /admin/quests/generate\（LLM 生成保存）は別 Issue に切り出し、今 PR には含まない。

| メソッド | パス | 説明 |
|---|---|---|
| GET | \/admin/quests\ | 一覧取得（skip/limit/category/difficulty フィルタ） |
| POST | \/admin/quests\ | 手動クエスト作成（QuestCreate  Quest 201） |
| DELETE | \/admin/quests/{id}\ | クエスト削除（204 / 404） |

## 🔧 技術的な意思決定とトレードオフ (最重要)

### 採用したアプローチ

- **手法**: 既存の \dmin_app\（FastAPI サブアプリ）に直接エンドポイントを追加。スキーマは公開 API と同じ \Quest\ クラスを流用
- **メリット**: \Quest\ スキーマを二重管理しなくて済む。一覧でも description が取得できる
- **デメリット/リスク**: 一覧で description（大きくなりうる）を常に返すためレスポンスが大きくなる可能性がある。件数増加後はページネーション上限（200件）で対応

### 却下したアプローチ（代替案）

- **手法**: \QuestSummary\（description なし）スキーマを別途定義して一覧用に使う
- **却下理由**: 管理画面ではdescriptionも確認したいケースがあるため、スキーマを分けるより \Quest\ を流用する方が実用的と判断

## 🧪 テスト戦略と範囲

### 追加したテストケース（10件）

- [x] 正常系: 空一覧、作成後一覧に含まれる、category/skip/limit フィルタ
- [x] 正常系: 手動作成でフィールドが正しく保存される、is_generated デフォルト False
- [x] 正常系: 削除成功（204）、削除後一覧から消える
- [x] 異常系: 存在しない ID の削除で 404
- [x] **テストしていないこと**: X-Admin-Key 認証の HTTP レベルテスト（E2E テストで対応予定）、difficulty バリデーション範囲外（0-9 外）のリジェクト、同時リクエストによる競合
<img width="1443" height="310" alt="ebea02fd9cabae6fe95b09e19db5c88e" src="https://github.com/user-attachments/assets/407a3539-cb14-414b-9d98-c56dc5b3e4b0" />

## セキュリティに関する自己評価

- [x] 機密情報のハードコードはないか（ADMIN_API_KEY は環境変数、テスト用ダミーは conftest のみ）
- [x] 入力値の検証（バリデーション）は行っているか（QuestCreate の difficulty バリデータ、skip/limit の ge/le 制約）
- [x] 既知の脆弱性パターンへの対策は考慮したか（Admin Key は \secrets.compare_digest\ でタイミング攻撃対策済み）

## レビュワー（人間）への申し送り事項

- \POST /admin/quests\ の \is_generated\ は現状リクエストから指定可能。将来的に LLM 生成クエストと手動クエストを厳密に区別する場合は固定化を検討
- \GET /admin/quests\ の上限は \_ADMIN_LIST_MAX = 200\ で抑えているが、クエスト数が増えた際はカーソルページネーションへの移行を検討

Closes #77