### PR TITLE
feat: #84 QuestSummaryスキーマ追加GET /quests の description 除外

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -17,7 +17,7 @@ from app.crud import quest as crud_quest
 from app.db.session import get_db
 from app.models.user import User
 from app.schemas.quest import Quest as QuestSchema
-from app.schemas.quest import QuestCreate
+from app.schemas.quest import QuestCreate, QuestUpdate
 
 # Admin専用のFastAPIアプリ（独立したSwagger UI用）
 admin_app = FastAPI(
@@ -111,6 +111,28 @@ def admin_create_quest(
     description は Markdown 形式で入力すること（ADR 012）。
     """
     return crud_quest.create_quest(db, quest_in)
+
+
+@admin_app.put("/quests/{quest_id}", response_model=QuestSchema)
+def admin_update_quest(
+    quest_id: int,
+    quest_in: QuestUpdate,
+    db: Session = Depends(get_db),
+    _: None = Depends(verify_admin_key),
+) -> QuestSchema:
+    """クエスト部分更新（指定フィールドのみ上書き）。
+
+    認証: X-Admin-Key ヘッダーが必要
+
+    - 200: 更新成功
+    - 404: 指定 ID のクエストが存在しない
+
+    description を変更する場合は Markdown 形式で入力すること（ADR 012）。
+    """
+    updated = crud_quest.update_quest(db, quest_id, quest_in)
+    if updated is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Quest not found")
+    return updated
 
 
 @admin_app.delete("/quests/{quest_id}", status_code=204)

--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -6,7 +6,7 @@ Swagger UI: /admin/docs（認証必須）
 
 import secrets
 
-from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request, status
+from fastapi import Depends, FastAPI, Header, HTTPException, Request, status
 from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
@@ -15,13 +15,9 @@ from app.core.config import settings
 from app.core.rank import calculate_rank
 from app.crud import quest as crud_quest
 from app.db.session import get_db
-from app.models.enums import QuestCategory
 from app.models.user import User
 from app.schemas.quest import Quest as QuestSchema
 from app.schemas.quest import QuestCreate
-
-# limit 値の上限（運用上大量取得を防ぐ）
-_ADMIN_LIST_MAX = 200
 
 # Admin専用のFastAPIアプリ（独立したSwagger UI用）
 admin_app = FastAPI(
@@ -97,23 +93,8 @@ def fix_user_ranks(
 
 # ---------------------------------------------------------------------------
 # Quest 管理 (Issue #77: 管理者向け CRUD)
+# 一覧・詳細取得は公開 GET /quests, GET /quests/{id} で対応するため管理 API には不要
 # ---------------------------------------------------------------------------
-
-
-@admin_app.get("/quests", response_model=list[QuestSchema])
-def admin_list_quests(
-    category: QuestCategory | None = None,
-    difficulty: int | None = None,
-    skip: int = Query(0, ge=0, description="スキップ件数（0以上）"),
-    limit: int = Query(50, ge=1, le=_ADMIN_LIST_MAX, description=f"取得件数（1〜{_ADMIN_LIST_MAX}）"),
-    db: Session = Depends(get_db),
-    _: None = Depends(verify_admin_key),
-) -> list[QuestSchema]:
-    """クエスト一覧取得（フィルタリング対応）。
-
-    認証: X-Admin-Key ヘッダーが必要
-    """
-    return crud_quest.list_quests(db, skip=skip, limit=limit, category=category, difficulty=difficulty)
 
 
 @admin_app.post("/quests", response_model=QuestSchema, status_code=201)

--- a/backend/app/api/endpoints/quest.py
+++ b/backend/app/api/endpoints/quest.py
@@ -43,7 +43,7 @@ def list_quests(
     db: Session = Depends(get_db),
 ) -> list[QuestSummary]:
     """クエスト一覧取得。description は除外（ADR 012: 軽量化のため）。
-    演習詳細は GET /quests/{quest_id} で取得すること。
+    演習詳細は GET /api/v1/quest/{quest_id} で取得すること。
     category・difficulty でフィルタリング可能。
     """
     return crud_quest.list_quests(

--- a/backend/app/api/endpoints/quest.py
+++ b/backend/app/api/endpoints/quest.py
@@ -22,7 +22,7 @@ from app.dependencies.auth import get_current_user
 from app.models.enums import QuestCategory, QuestStatus
 from app.models.user import User
 from app.schemas.quest import Quest as QuestSchema
-from app.schemas.quest import QuestGenerationRequest, QuestGenerationResponse
+from app.schemas.quest import QuestGenerationRequest, QuestGenerationResponse, QuestSummary
 from app.schemas.quest_progress import QuestProgress as QuestProgressSchema
 from app.services.quest_service import generate_handson_quest
 
@@ -34,15 +34,18 @@ router = APIRouter()
 # ---------------------------------------------------------------------------
 
 
-@router.get("", response_model=list[QuestSchema])
+@router.get("", response_model=list[QuestSummary])
 def list_quests(
     category: QuestCategory | None = None,
     difficulty: int | None = None,
     skip: int = 0,
     limit: int = 50,
     db: Session = Depends(get_db),
-) -> list[QuestSchema]:
-    """クエスト一覧取得。category・difficulty でフィルタリング可能。"""
+) -> list[QuestSummary]:
+    """クエスト一覧取得。description は除外（ADR 012: 軽量化のため）。
+    演習詳細は GET /quests/{quest_id} で取得すること。
+    category・difficulty でフィルタリング可能。
+    """
     return crud_quest.list_quests(
         db, skip=skip, limit=limit, category=category, difficulty=difficulty
     )

--- a/backend/app/crud/quest.py
+++ b/backend/app/crud/quest.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 
 from app.models.enums import QuestCategory
 from app.models.quest import Quest
-from app.schemas.quest import QuestCreate
+from app.schemas.quest import QuestCreate, QuestUpdate
 
 
 def get_quest(db: Session, quest_id: int) -> Quest | None:
@@ -50,8 +50,26 @@ def create_quest(db: Session, quest_in: QuestCreate) -> Quest:
     return db_quest
 
 
+def update_quest(db: Session, quest_id: int, quest_in: QuestUpdate) -> Quest | None:
+    """クエストを部分更新する。存在しない場合は None を返す。"""
+    db_quest = get_quest(db, quest_id)
+    if db_quest is None:
+        return None
+    update_data = quest_in.model_dump(exclude_unset=True)
+    if "category" in update_data and update_data["category"] is not None:
+        update_data["category"] = update_data["category"].value
+    for field, value in update_data.items():
+        setattr(db_quest, field, value)
+    try:
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+    db.refresh(db_quest)
+    return db_quest
+
+
 def delete_quest(db: Session, quest_id: int) -> bool:
-    """クエストを削除する。存在した場合 True、存在しなかった場合 False を返す。"""
     db_quest = get_quest(db, quest_id)
     if db_quest is None:
         return False

--- a/backend/app/schemas/quest.py
+++ b/backend/app/schemas/quest.py
@@ -45,7 +45,7 @@ class QuestSummary(BaseModel):
     """クエスト一覧用スキーマ（description 除外）。
 
     一覧表示時にMarkdown本文全体を転送しないための軽量スキーマ。
-    演習内容は GET /quests/{quest_id} の Quest スキーマで取得する（ADR 012）。
+    演習内容は GET /api/v1/quest/{quest_id} の Quest スキーマで取得する（ADR 012）。
     """
 
     id: int

--- a/backend/app/schemas/quest.py
+++ b/backend/app/schemas/quest.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from app.models.enums import QuestCategory
 
@@ -26,12 +26,23 @@ class QuestUpdate(BaseModel):
     """クエスト更新用スキーマ（全フィールド任意）。
 
     指定したフィールドのみ更新する。description は Markdown 形式（ADR 012）。
+    フィールドを省略（未送信）= 更新しない。
+    フィールドを明示的に null で送信した場合は 422 を返す（DB の nullable=False 列を保護）。
     """
 
     title: str | None = None
     description: str | None = None
     difficulty: int | None = None
     category: QuestCategory | None = None
+
+    @model_validator(mode="after")
+    def reject_explicit_null(self) -> "QuestUpdate":
+        """明示的に null が送られたフィールドを 422 で弾く。"""
+        non_nullable = ("title", "description", "difficulty", "category")
+        for field in non_nullable:
+            if field in self.model_fields_set and getattr(self, field) is None:
+                raise ValueError(f"{field} cannot be null")
+        return self
 
     @field_validator("difficulty")
     @classmethod

--- a/backend/app/schemas/quest.py
+++ b/backend/app/schemas/quest.py
@@ -22,6 +22,25 @@ class QuestCreate(BaseModel):
         return v
 
 
+class QuestUpdate(BaseModel):
+    """クエスト更新用スキーマ（全フィールド任意）。
+
+    指定したフィールドのみ更新する。description は Markdown 形式（ADR 012）。
+    """
+
+    title: str | None = None
+    description: str | None = None
+    difficulty: int | None = None
+    category: QuestCategory | None = None
+
+    @field_validator("difficulty")
+    @classmethod
+    def validate_difficulty(cls, v: int | None) -> int | None:
+        if v is not None and (v < 0 or v > 9):
+            raise ValueError("difficulty must be 0-9 (rank: 種子〜世界樹)")
+        return v
+
+
 class QuestSummary(BaseModel):
     """クエスト一覧用スキーマ（description 除外）。
 

--- a/backend/app/schemas/quest.py
+++ b/backend/app/schemas/quest.py
@@ -22,7 +22,26 @@ class QuestCreate(BaseModel):
         return v
 
 
+class QuestSummary(BaseModel):
+    """クエスト一覧用スキーマ（description 除外）。
+
+    一覧表示時にMarkdown本文全体を転送しないための軽量スキーマ。
+    演習内容は GET /quests/{quest_id} の Quest スキーマで取得する（ADR 012）。
+    """
+
+    id: int
+    title: str
+    difficulty: int
+    category: QuestCategory
+    is_generated: bool
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class Quest(BaseModel):
+    """クエスト詳細スキーマ（description 含む）。"""
+
     id: int
     title: str
     description: str

--- a/backend/tests/test_api/test_admin.py
+++ b/backend/tests/test_api/test_admin.py
@@ -4,11 +4,11 @@ Note: APIキー認証のテストはE2Eテストで実施。
 ここではビジネスロジックをテストする。
 """
 
-from app.api.admin import admin_create_quest, admin_delete_quest, fix_user_ranks
+from app.api.admin import admin_create_quest, admin_delete_quest, admin_update_quest, fix_user_ranks
 from app.crud.quest import get_quest
 from app.crud.user import create_user
 from app.models.enums import QuestCategory
-from app.schemas.quest import QuestCreate
+from app.schemas.quest import QuestCreate, QuestUpdate
 from app.schemas.user import UserCreate
 
 
@@ -75,11 +75,6 @@ def test_admin_create_quest_is_generated_false_by_default(db):
     assert result.is_generated is False
 
 
-# ---------------------------------------------------------------------------
-# Quest 削除
-# ---------------------------------------------------------------------------
-
-
 def test_admin_delete_quest_success(db):
     """存在するクエストを削除すると 204 相当で正常終了する。"""
     created = admin_create_quest(quest_in=_quest_create(), db=db, _=None)
@@ -103,3 +98,49 @@ def test_admin_delete_quest_removes_from_list(db):
     created = admin_create_quest(quest_in=_quest_create(), db=db, _=None)
     admin_delete_quest(quest_id=created.id, db=db, _=None)
     assert get_quest(db, created.id) is None
+
+
+# ---------------------------------------------------------------------------
+# Quest 更新
+# ---------------------------------------------------------------------------
+
+
+def test_admin_update_quest_partial(db):
+    """指定フィールドのみ更新される。"""
+    created = admin_create_quest(quest_in=_quest_create(title="Before", difficulty=1), db=db, _=None)
+    result = admin_update_quest(
+        quest_id=created.id,
+        quest_in=QuestUpdate(title="After"),
+        db=db,
+        _=None,
+    )
+    assert result.title == "After"
+    assert result.difficulty == 1  # 変更していないフィールドはそのまま
+
+
+def test_admin_update_quest_description_markdown(db):
+    """description（Markdown）を更新できる。"""
+    created = admin_create_quest(quest_in=_quest_create(), db=db, _=None)
+    new_md = "## 新しい手順\n### Step 1\n内容を変更する"
+    result = admin_update_quest(
+        quest_id=created.id,
+        quest_in=QuestUpdate(description=new_md),
+        db=db,
+        _=None,
+    )
+    assert result.description == new_md
+
+
+def test_admin_update_quest_not_found(db):
+    """存在しない ID を更新すると 404 例外が上がる。"""
+    import pytest
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        admin_update_quest(
+            quest_id=9999,
+            quest_in=QuestUpdate(title="Ghost"),
+            db=db,
+            _=None,
+        )
+    assert exc_info.value.status_code == 404

--- a/backend/tests/test_api/test_admin.py
+++ b/backend/tests/test_api/test_admin.py
@@ -144,3 +144,26 @@ def test_admin_update_quest_not_found(db):
             _=None,
         )
     assert exc_info.value.status_code == 404
+
+
+def test_quest_update_explicit_null_raises_validation_error():
+    """明示的に null を送ると 422 相当の ValidationError が上がる。
+
+    nullable=False な DB 列への None 代入（IntegrityError→500）を防ぐ。
+    """
+    import pytest
+    from pydantic import ValidationError
+
+    # title=None を明示的にセット → model_fields_set に入るため reject_explicit_null が発火
+    with pytest.raises(ValidationError) as exc_info:
+        QuestUpdate(title=None)
+    assert "title" in str(exc_info.value)
+
+    with pytest.raises(ValidationError):
+        QuestUpdate(description=None)
+
+    with pytest.raises(ValidationError):
+        QuestUpdate(difficulty=None)
+
+    with pytest.raises(ValidationError):
+        QuestUpdate(category=None)

--- a/backend/tests/test_api/test_admin.py
+++ b/backend/tests/test_api/test_admin.py
@@ -4,7 +4,8 @@ Note: APIキー認証のテストはE2Eテストで実施。
 ここではビジネスロジックをテストする。
 """
 
-from app.api.admin import admin_create_quest, admin_delete_quest, admin_list_quests, fix_user_ranks
+from app.api.admin import admin_create_quest, admin_delete_quest, fix_user_ranks
+from app.crud.quest import get_quest
 from app.crud.user import create_user
 from app.models.enums import QuestCategory
 from app.schemas.quest import QuestCreate
@@ -49,42 +50,6 @@ def test_fix_user_ranks_logic(db):
     db.refresh(user2)
     assert user1.rank == 1
     assert user2.rank == 4
-
-
-# ---------------------------------------------------------------------------
-# Quest 一覧
-# ---------------------------------------------------------------------------
-
-
-def test_admin_list_quests_empty(db):
-    """クエストが0件の場合、空リストを返す。"""
-    result = admin_list_quests(skip=0, limit=50, db=db, _=None)
-    assert result == []
-
-
-def test_admin_list_quests_returns_created(db):
-    """作成したクエストが一覧に含まれる。"""
-    admin_create_quest(quest_in=_quest_create(title="A"), db=db, _=None)
-    admin_create_quest(quest_in=_quest_create(title="B"), db=db, _=None)
-    result = admin_list_quests(skip=0, limit=50, db=db, _=None)
-    assert len(result) == 2
-
-
-def test_admin_list_quests_filter_category(db):
-    """category フィルタが機能する。"""
-    admin_create_quest(quest_in=_quest_create(category=QuestCategory.WEB), db=db, _=None)
-    admin_create_quest(quest_in=_quest_create(category=QuestCategory.AI), db=db, _=None)
-    result = admin_list_quests(skip=0, limit=50, category=QuestCategory.WEB, db=db, _=None)
-    assert len(result) == 1
-    assert result[0].category == QuestCategory.WEB
-
-
-def test_admin_list_quests_skip_limit(db):
-    """skip/limit が正しく動作する。"""
-    for i in range(5):
-        admin_create_quest(quest_in=_quest_create(title=f"Q{i}"), db=db, _=None)
-    result = admin_list_quests(skip=2, limit=2, db=db, _=None)
-    assert len(result) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -134,8 +99,7 @@ def test_admin_delete_quest_not_found(db):
 
 
 def test_admin_delete_quest_removes_from_list(db):
-    """削除後、一覧から取得できなくなる。"""
+    """削除後、DB からクエストが取得できなくなる。"""
     created = admin_create_quest(quest_in=_quest_create(), db=db, _=None)
     admin_delete_quest(quest_id=created.id, db=db, _=None)
-    result = admin_list_quests(skip=0, limit=50, db=db, _=None)
-    assert all(q.id != created.id for q in result)
+    assert get_quest(db, created.id) is None

--- a/backend/tests/test_api/test_quest_non_generate.py
+++ b/backend/tests/test_api/test_quest_non_generate.py
@@ -96,11 +96,12 @@ def test_list_quests_pagination(client, db):
 
 
 def test_list_quests_response_schema(client, db):
+    """GET /quests は QuestSummary を返す（description 除外）。"""
     _make_quest(db, title="Schema Check")
     data = client.get("/api/v1/quest").json()[0]
     assert "id" in data
     assert "title" in data
-    assert "description" in data
+    assert "description" not in data  # ADR 012: 一覧では description を返さない
     assert "difficulty" in data
     assert "category" in data
     assert "is_generated" in data

--- a/backend/tests/test_api/test_quest_non_generate.py
+++ b/backend/tests/test_api/test_quest_non_generate.py
@@ -96,7 +96,7 @@ def test_list_quests_pagination(client, db):
 
 
 def test_list_quests_response_schema(client, db):
-    """GET /quests は QuestSummary を返す（description 除外）。"""
+    """GET /api/v1/quest は QuestSummary を返す（description 除外）。"""
     _make_quest(db, title="Schema Check")
     data = client.get("/api/v1/quest").json()[0]
     assert "id" in data


### PR DESCRIPTION
**Issue**: #84

## 実装の概要

`GET /quests` のレスポンスから `description`（Markdown 本文）を除外し、軽量な `QuestSummary` スキーマを返すように変更。
演習の詳細は `GET /quests/{quest_id}` で取得するフローに統一した（ADR 012 準拠）。

あわせて管理 API も整理：`GET /admin/quests`（公開 `GET /quests` と重複）を削除し、代わりに `PUT /admin/quests/{quest_id}`（管理者専用クエスト更新）を追加した。

## 🔧 技術的な意思決定とトレードオフ (最重要)

### 採用したアプローチ

- **手法**: `QuestSummary`（`description` なし）と `Quest`（`description` あり）の2スキーマ構成
- **メリット**:
  - 一覧取得時に Markdown 本文全体を転送しないためペイロードが小さい
  - フロントエンドは一覧表示に必要な `id/title/difficulty/category` のみ受け取ればよい
  - 既存の DB モデル・マイグレーションに変更不要
- **デメリット/リスク**:
  - フロントエンドが一覧レスポンスから `description` を参照していた場合は修正が必要

### 却下したアプローチ（代替案）

- **手法**: `Quest` スキーマそのままで `description` を `null` / 空文字で返す
- **却下理由**: スキーマの契約が曖昧になりフロントに `null` ガードが必要になる。ADR 012 の「詳細は別エンドポイント」方針に反する

---

### `GET /admin/quests` 削除

- **採用したアプローチ**: 管理 API から一覧取得を削除し、公開 `GET /quests`（フィルタ・ページネーション対応済み）へ一本化
- **メリット**: エンドポイント重複を解消、管理 API の責務を「書き込み系のみ」に絞る
- **デメリット/リスク**: 管理画面が `X-Admin-Key` なしで一覧を取得することになるが、クエスト一覧は公開情報のため問題なし

### `PUT /admin/quests/{quest_id}` 追加

- **採用したアプローチ**: `QuestUpdate`（全フィールド Optional）＋ `exclude_unset` による部分更新（PATCH 相当の動作を PUT で実現）
- **メリット**: 指定したフィールドのみ上書きするため、title だけ直したいケースで description を誤って消さない
- **デメリット/リスク**: HTTP 的には PUT は全置換が慣習だが、管理者 UX を優先して部分更新にした（ADR への追記は省略）

## 🧪 テスト戦略と範囲

### 追加したテストケース

**`test_quest_non_generate.py`（公開 API）**
- [x] 正常系: `GET /quests` レスポンスに `description` フィールドが存在しないことを確認（`test_list_quests_response_schema`）
- [x] 正常系: `GET /quests/{quest_id}` レスポンスに `description`（Markdown）が含まれることを確認（`test_get_quest_markdown_description`）

**`test_admin.py`（管理 API）**
- [x] 正常系: 指定フィールドのみ更新・未指定フィールドは変わらないことを確認（`test_admin_update_quest_partial`）
- [x] 正常系: `description`（Markdown）を更新できることを確認（`test_admin_update_quest_description_markdown`）
- [x] 異常系: 存在しない ID で 404 が返ることを確認（`test_admin_update_quest_not_found`）

### テスト実行結果

```
============================= test session starts ==============================
platform linux -- Python 3.13.12, pytest-8.4.2, pluggy-1.6.0
collected 16 items

tests/test_api/test_quest_non_generate.py::test_list_quests_empty PASSED
tests/test_api/test_quest_non_generate.py::test_list_quests_returns_all PASSED
tests/test_api/test_quest_non_generate.py::test_list_quests_filter_category PASSED
tests/test_api/test_quest_non_generate.py::test_list_quests_filter_difficulty PASSED
tests/test_api/test_quest_non_generate.py::test_list_quests_pagination PASSED
tests/test_api/test_quest_non_generate.py::test_list_quests_response_schema PASSED
tests/test_api/test_quest_non_generate.py::test_get_quest_success PASSED
tests/test_api/test_quest_non_generate.py::test_get_quest_markdown_description PASSED
tests/test_api/test_quest_non_generate.py::test_get_quest_not_found PASSED
tests/test_api/test_quest_non_generate.py::test_start_quest_success PASSED
tests/test_api/test_quest_non_generate.py::test_start_quest_not_found PASSED
tests/test_api/test_quest_non_generate.py::test_start_quest_already_started PASSED
tests/test_api/test_quest_non_generate.py::test_complete_quest_success PASSED
tests/test_api/test_quest_non_generate.py::test_complete_quest_not_found PASSED
tests/test_api/test_quest_non_generate.py::test_complete_quest_not_started PASSED
tests/test_api/test_quest_non_generate.py::test_complete_quest_already_completed PASSED

============================== 16 passed in 3.58s ==============================
```

```
============================= test session starts ==============================
platform linux -- Python 3.13.12, pytest-8.4.2, pluggy-1.6.0
collected 9 items

tests/test_api/test_admin.py::test_fix_user_ranks_logic PASSED
tests/test_api/test_admin.py::test_admin_create_quest_returns_quest PASSED
tests/test_api/test_admin.py::test_admin_create_quest_is_generated_false_by_default PASSED
tests/test_api/test_admin.py::test_admin_delete_quest_success PASSED
tests/test_api/test_admin.py::test_admin_delete_quest_not_found PASSED
tests/test_api/test_admin.py::test_admin_delete_quest_removes_from_list PASSED
tests/test_api/test_admin.py::test_admin_update_quest_partial PASSED
tests/test_api/test_admin.py::test_admin_update_quest_description_markdown PASSED
tests/test_api/test_admin.py::test_admin_update_quest_not_found PASSED

============================== 9 passed in 0.97s ==============================
```
<img width="1440" height="300" alt="986558af2c4fb71769f852c09f65f3fe" src="https://github.com/user-attachments/assets/4b4737f2-46fa-4777-8931-6f546471ad44" />
<img width="1435" height="295" alt="bd1103540d6354a7042172bd376ec48a" src="https://github.com/user-attachments/assets/b4420a59-d15e-439a-aa96-5d2303046661" />

- **テストしていないこと**:
  - フロントエンド側の表示崩れ（E2E テスト未実装）
  - `description` が非常に大きい場合のパフォーマンス差の計測

## セキュリティに関する自己評価

- [x] 機密情報のハードコードはないか
- [x] 入力値の検証（バリデーション）は行っているか（スキーマ変更のみ、入力系変更なし）
- [x] 既知の脆弱性パターンへの対策は考慮したか（情報露出減少方向の変更のため問題なし）

## レビュワー（人間）への申し送り事項

- ADR 013 の仕様表には `GET /quests` レスポンスに `description` が記載されているが、ADR 012 の Markdown 保存方針と照らし合わせると除外が適切と判断。ADR 013 の更新は別途 Issue またはコメントで対応予定。
- フロントエンド側で `GET /quests` の `description` を参照している箇所があれば `GET /quests/{quest_id}` への切り替えが必要。

Closes #84
