### PR TITLE
feat: #71 GitHub OAuth認証とスキルツリー自動生成の統合、認証ガード実装

### DIFF
--- a/.github/decisions/IMPLEMENTATION_ISSUE_71.md
+++ b/.github/decisions/IMPLEMENTATION_ISSUE_71.md
@@ -1,0 +1,201 @@
+# Issue #71: GitHub OAuth認証とスキルツリー生成の統合
+
+## 実装概要
+
+GitHub OAuthを使った認証機能を実装し、認証後にユーザーのGitHubリポジトリを分析してパーソナライズされたスキルツリーを自動生成する機能を統合しました。
+
+## 実装内容
+
+### 1. ログイン画面の改善 (`frontend/src/app/login/page.tsx`)
+
+- **デザイン改善**:
+  - グラデーション背景の追加
+  - アイコン追加（🌳）
+  - アニメーション効果（スライドアップ、シェイク、スライドダウン）
+  - GitHubログインボタンの視覚効果強化（シャインエフェクト）
+  - ローディング状態の改善（スピナー表示）
+- **UI/UX改善**:
+  - テストユーザー情報を折りたたみ可能に変更
+  - エラーメッセージのスタイル改善
+  - ボタンのホバー/アクティブ状態のアニメーション
+
+### 2. OAuth callback時のProfile自動作成 (`backend/app/api/endpoints/auth.py`)
+
+- **新規ユーザー登録時**:
+  - User、OAuthAccount、Profileを同一トランザクションで作成
+  - GitHubのログイン名を `github_username` として自動設定
+  - アトミック性を保証（一部だけが保存されるゾンビレコードを防止）
+
+- **既存ユーザーログイン時**:
+  - Profileが存在しない場合は自動作成（マイグレーション対策）
+  - 失敗してもログインは継続（Warningログのみ）
+
+### 3. Profile CRUD操作の改善 (`backend/app/crud/profile.py`)
+
+- `create_profile()` に `commit` パラメータを追加
+- `commit=False` の場合は `flush()` のみ実行（トランザクション制御用）
+
+### 4. スキルツリーAPIエンドポイントの改善 (`backend/app/api/endpoints/users.py`)
+
+- `/users/me/skill-trees` エンドポイントに `category` クエリパラメータを追加
+- カテゴリでフィルタリング可能に
+- 未指定の場合は全カテゴリを返却（後方互換性維持）
+
+## 動作フロー
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant F as Frontend
+    participant B as Backend
+    participant GH as GitHub
+
+    U->>F: ログインページアクセス
+    U->>F: 「GitHubでログイン」クリック
+    F->>B: GET /api/v1/auth/github/login
+    B->>GH: 認可ページへリダイレクト
+    GH->>U: 認可確認
+    U->>GH: Authorize
+    GH->>B: Callback with code
+    B->>GH: Access Token取得
+    B->>GH: ユーザー情報取得
+    B->>B: User + OAuthAccount + Profile作成
+    B->>F: ダッシュボードへリダイレクト（JWT Cookie付与）
+    F->>B: GET /users/me/skill-trees?category=web
+    alt スキルツリーが存在しない
+        F->>B: POST /analyze/skill-tree
+        B->>GH: リポジトリ分析
+        B->>B: スキルツリー生成
+        B->>F: スキルツリーデータ返却
+    else スキルツリーが存在する
+        B->>F: 既存スキルツリー返却
+    end
+    F->>U: スキルツリー表示
+```
+
+## セットアップ手順
+
+### 1. GitHub OAuth Appの作成
+
+詳細は [docs/GITHUB_OAUTH_SETUP.md](../docs/GITHUB_OAUTH_SETUP.md) を参照してください。
+
+**簡易手順**:
+
+1. [GitHub Developer Settings](https://github.com/settings/developers) にアクセス
+2. 「New OAuth App」をクリック
+3. 以下を設定:
+   - Homepage URL: `http://localhost:3000`
+   - Authorization callback URL: `http://localhost:8000/api/v1/auth/github/callback`
+4. Client IDとClient Secretを取得
+
+### 2. 環境変数の設定
+
+`backend/.env` ファイルに以下を設定:
+
+```dotenv
+# GitHub OAuth
+GITHUB_CLIENT_ID=<取得したClient ID>
+GITHUB_CLIENT_SECRET=<取得したClient Secret>
+
+# JWT設定（必須）
+JWT_SECRET_KEY=<ランダムな文字列>
+
+# 暗号化キー（必須）
+ENCRYPTION_KEY=<Fernetキー>
+
+# GitHub API Token（オプション、Rate Limit緩和）
+GITHUB_API_TOKEN=<Personal Access Token>
+```
+
+**キー生成方法**:
+
+```bash
+# JWT Secret Key
+python -c "import secrets; print(secrets.token_hex(32))"
+
+# Encryption Key
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
+### 3. 起動
+
+```bash
+# バックエンド
+cd backend
+poetry install
+poetry run uvicorn app.main:app --reload
+
+# フロントエンド（別ターミナル）
+cd frontend
+npm install
+npm run dev
+```
+
+### 4. 動作確認
+
+1. `http://localhost:3000/login` にアクセス
+2. 「🚀 GitHub でログイン（推奨）」ボタンをクリック
+3. GitHubの認可ページで「Authorize」をクリック
+4. ダッシュボードにリダイレクトされ、スキルツリーが表示される
+
+## セキュリティ対策
+
+### 実装済みの対策
+
+1. **CSRF対策** (ADR 014):
+   - HMAC署名付きstateパラメータ
+   - Cookie バインディング検証
+
+2. **XSS対策**:
+   - httpOnly Cookie（JavaScriptからアクセス不可）
+   - JWT を URL パラメータに含めない
+
+3. **トークン暗号化** (ADR 005):
+   - OAuthアクセストークンはFernetで暗号化してDB保存
+   - `ENCRYPTION_KEY` が未設定の場合は起動時にエラー
+
+4. **最小権限の原則**:
+   - GitHub OAuth スコープは `read:user` のみ要求
+
+5. **入力検証**:
+   - username: 1〜72文字制限（ADR 017）
+   - password: 1〜128文字制限（PBKDF2 DoS対策）
+
+## テスト
+
+```bash
+cd backend
+poetry run pytest tests/test_api/test_auth.py -v
+poetry run pytest tests/test_services/test_skill_tree_service.py -v
+```
+
+## トラブルシューティング
+
+### エラー: "GitHub OAuth は設定されていません"
+
+→ `.env` の `GITHUB_CLIENT_ID` と `GITHUB_CLIENT_SECRET` を確認し、バックエンドを再起動
+
+### エラー: "Invalid or expired state parameter"
+
+→ GitHub OAuth Appの `Authorization callback URL` が正しいか確認
+
+### スキルツリーが表示されない
+
+→ ブラウザの開発者ツールでネットワークタブを確認:
+
+- `/users/me/skill-trees` が 200 を返しているか？
+- 404の場合: Profileが作成されていない可能性（DBを確認）
+- 500の場合: バックエンドログを確認
+
+## 関連Issue
+
+- Issue #71: GitHub OAuth認証とスキルツリー生成の統合
+- Issue #59: GitHub OAuth認証の実装
+- Issue #61: 認証統合（Cookie ベース）
+- Issue #54: スキルツリー生成（LLM実装）
+
+## ADR参照
+
+- ADR 014: JWT Cookie ベース認証
+- ADR 005: OAuthトークンの暗号化保存
+- ADR 017: 入力バリデーション戦略

--- a/backend/app/api/endpoints/auth.py
+++ b/backend/app/api/endpoints/auth.py
@@ -15,6 +15,7 @@
 
 import hashlib
 import hmac
+import logging
 import secrets
 import time
 from datetime import datetime, timedelta, timezone
@@ -32,9 +33,11 @@ from app.core.config import settings
 from app.core.password import verify_password
 from app.crud import oauth_account as crud_oauth
 from app.crud import user as crud_user
+from app.crud import profile as crud_profile
 from app.db.session import get_db
 from app.schemas.oauth_account import OAuthAccountCreate, OAuthTokenUpdate
 from app.schemas.user import UserCreate
+from app.schemas.profile import ProfileCreate
 
 router = APIRouter()
 
@@ -286,16 +289,32 @@ async def github_callback(
             OAuthTokenUpdate(access_token=access_token),
         )
         db_user = crud_user.get_user(db, existing_oauth.user_id)
+
+        # 既存ユーザーでもProfileが存在しない場合は作成（マイグレーション対策: Issue #71）
+        if db_user and not crud_profile.get_profile_by_user_id(db, db_user.id):
+            try:
+                crud_profile.create_profile(
+                    db,
+                    ProfileCreate(
+                        user_id=db_user.id,
+                        github_username=github_login_name,
+                    ),
+                )
+            except Exception as e:
+                # Profileの作成に失敗してもログインは継続（Warning のみ）
+                logger = logging.getLogger(__name__)
+                logger.warning(
+                    f"Failed to create profile for user_id={db_user.id}: {e}"
+                )
     else:
         # 新規登録: username の重複回避
         username = github_login_name
         if crud_user.get_user_by_username(db, username) is not None:
             username = f"{github_login_name}_{github_user_id}"
 
-        # User と OAuthAccount を同一トランザクションで作成（アトミック性保証）
-        # commit=False にして両方を flush した後、一括 commit する。
+        # User と OAuthAccount と Profile を同一トランザクションで作成（アトミック性保証）
+        # commit=False にして全てを flush した後、一括 commit する。
         # これにより「User だけが永続化されるゾンビレコード」を防ぐ。
-        # create_user / create_oauth_account の flush も含めて全体を囲う（C-1修正）
         try:
             db_user = crud_user.create_user(
                 db, UserCreate(username=username), commit=False
@@ -308,6 +327,15 @@ async def github_callback(
                     provider="github",
                     provider_user_id=github_user_id,
                     access_token=access_token,
+                ),
+                commit=False,
+            )
+            # Profile 作成（スキルツリー生成に必要: Issue #71）
+            crud_profile.create_profile(
+                db,
+                ProfileCreate(
+                    user_id=db_user.id,
+                    github_username=github_login_name,
                 ),
                 commit=False,
             )

--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -8,7 +8,7 @@ rank 管理方針は ADR 010 参照。
 /users/{id} 系の管理者向けエンドポイントは、別途管理 API モジュール／Issue で扱う。
 """
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from app.crud import badge as crud_badge
@@ -19,6 +19,7 @@ from app.crud import user as crud_user
 from app.db.session import get_db
 from app.dependencies.auth import get_current_user
 from app.models.user import User
+from app.models.enums import SkillCategory
 from app.schemas.badge import Badge as BadgeSchema
 from app.schemas.profile import Profile as ProfileSchema
 from app.schemas.profile import ProfileCreate, ProfileUpdate
@@ -103,11 +104,33 @@ def get_my_badges(
 
 @router.get("/me/skill-trees", response_model=list[SkillTreeSchema])
 def get_my_skill_trees(
+    category: str | None = Query(
+        None,
+        description="スキルカテゴリでフィルタ（web/ai/security/infrastructure/game/design）",
+    ),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> list[SkillTreeSchema]:
-    """認証済みユーザー自身のスキルツリー一覧取得（6カテゴリ）。"""
-    return crud_skill_tree.get_skill_trees_by_user(db, current_user.id)
+    """認証済みユーザー自身のスキルツリー取得。
+
+    category パラメータが指定された場合は該当カテゴリのみ返却。
+    未指定の場合は全カテゴリ（6カテゴリ）を返却。
+    """
+    all_trees = crud_skill_tree.get_skill_trees_by_user(db, current_user.id)
+
+    if category:
+        # categoryでフィルタリング
+        try:
+            # 文字列をEnumに変換して検証
+            cat_enum = SkillCategory(category.lower())
+            return [tree for tree in all_trees if tree.category == cat_enum.value]
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid category: {category}. Valid values: web, ai, security, infrastructure, game, design",
+            )
+
+    return all_trees
 
 
 @router.get("/me/quest-progress", response_model=list[QuestProgressSchema])

--- a/backend/app/crud/profile.py
+++ b/backend/app/crud/profile.py
@@ -11,24 +11,35 @@ def get_profile_by_user_id(db: Session, user_id: int) -> Profile | None:
     return db.query(Profile).filter(Profile.user_id == user_id).first()
 
 
-def create_profile(db: Session, profile_in: ProfileCreate) -> Profile:
+def create_profile(
+    db: Session, profile_in: ProfileCreate, commit: bool = True
+) -> Profile:
     data = profile_in.model_dump()
     # HttpUrlをstrに変換
     if data.get("portfolio_url"):
         data["portfolio_url"] = str(data["portfolio_url"])
     db_profile = Profile(**data)
     db.add(db_profile)
-    try:
-        db.commit()
-    except IntegrityError as e:
-        db.rollback()
-        raise ValueError(
-            f"Profile for user_id={profile_in.user_id} already exists"
-        ) from e
-    except Exception:
-        db.rollback()
-        raise
-    db.refresh(db_profile)
+    if commit:
+        try:
+            db.commit()
+        except IntegrityError as e:
+            db.rollback()
+            raise ValueError(
+                f"Profile for user_id={profile_in.user_id} already exists"
+            ) from e
+        except Exception:
+            db.rollback()
+            raise
+        db.refresh(db_profile)
+    else:
+        try:
+            db.flush()
+        except IntegrityError as e:
+            db.rollback()
+            raise ValueError(
+                f"Profile for user_id={profile_in.user_id} already exists"
+            ) from e
     return db_profile
 
 

--- a/backend/tests/test_api/test_auth.py
+++ b/backend/tests/test_api/test_auth.py
@@ -136,6 +136,37 @@ def test_callback_new_user_creates_user_and_sets_cookie(client):
     assert "httponly" in set_cookie_header.lower()
 
 
+def test_callback_new_user_creates_profile_with_github_username(client, db):
+    """初回ログイン: User + OAuthAccount + Profile が同一トランザクションで作成され、
+    Profile.github_username が GitHub login 名で設定される (Issue #71)。"""
+    state = _valid_state()
+    client.cookies.set("oauth_state", state)
+    mock_client = _mock_httpx_client()
+
+    with patch("app.api.endpoints.auth.httpx.AsyncClient", return_value=mock_client):
+        res = client.get(f"/api/v1/auth/github/callback?code=fake_code&state={state}")
+
+    assert res.status_code == 302
+
+    # JWT デコードして user_id を取得
+    import jwt as _jwt
+    from app.core.config import settings as _settings
+
+    token = res.cookies.get("access_token")
+    assert token is not None
+    payload = _jwt.decode(
+        token, _settings.JWT_SECRET_KEY, algorithms=[_settings.JWT_ALGORITHM]
+    )
+    user_id = int(payload["sub"])
+
+    # Profile が作成されていることを確認
+    from app.crud.profile import get_profile_by_user_id
+
+    profile = get_profile_by_user_id(db, user_id)
+    assert profile is not None
+    assert profile.github_username == FAKE_GITHUB_USER["login"]
+
+
 def test_callback_new_user_username_collision(client, db):
     """GitHub のログイン名がすでに使われている場合は username に ID を付与。"""
     state = _valid_state()
@@ -200,6 +231,50 @@ def test_callback_existing_user_updates_token(client):
 
     assert res2.status_code == 302
     assert "access_token" in res2.cookies
+
+
+def test_callback_existing_user_without_profile_creates_profile(client, db):
+    """既存ユーザーで Profile が欠損している場合、GitHub OAuth ログイン時に
+    Profile を自動作成する（移行ケース対応: Issue #71）。"""
+    # 既存ユーザーを Profile なしで準備（移行前データを模倣）
+    from app.crud.user import create_user as db_create_user
+    from app.crud.oauth_account import create_oauth_account
+    from app.schemas.user import UserCreate
+    from app.schemas.oauth_account import OAuthAccountCreate
+
+    existing_user = db_create_user(
+        db, UserCreate(username="legacy_user", password=None)
+    )
+    # OAuthAccount は存在するが Profile は存在しない状態
+    create_oauth_account(
+        db,
+        OAuthAccountCreate(
+            user_id=existing_user.id,
+            provider="github",
+            provider_user_id=str(FAKE_GITHUB_USER["id"]),
+            access_token="old_token",
+        ),
+    )
+    db.commit()
+
+    # Profile が存在しないことを確認
+    from app.crud.profile import get_profile_by_user_id
+
+    assert get_profile_by_user_id(db, existing_user.id) is None
+
+    # OAuth callback でログイン
+    state = _valid_state()
+    client.cookies.set("oauth_state", state)
+    mock_client = _mock_httpx_client()
+    with patch("app.api.endpoints.auth.httpx.AsyncClient", return_value=mock_client):
+        res = client.get(f"/api/v1/auth/github/callback?code=fake_code&state={state}")
+
+    assert res.status_code == 302
+
+    # Profile が自動作成されたことを確認
+    profile = get_profile_by_user_id(db, existing_user.id)
+    assert profile is not None
+    assert profile.github_username == FAKE_GITHUB_USER["login"]
 
 
 # ---------------------------------------------------------------------------

--- a/docs/GITHUB_OAUTH_SETUP.md
+++ b/docs/GITHUB_OAUTH_SETUP.md
@@ -1,0 +1,103 @@
+# GitHub OAuth App セットアップガイド
+
+このガイドでは、GitHub OAuthを使った認証機能を有効にするための設定手順を説明します。
+
+## 前提条件
+
+- GitHubアカウント
+- アプリケーションのローカル開発環境（バックエンド: `http://localhost:8000`, フロントエンド: `http://localhost:3000`）
+
+## 手順
+
+### 1. GitHub OAuth Appの作成
+
+1. GitHubにログインし、[Settings > Developer settings > OAuth Apps](https://github.com/settings/developers) にアクセスします
+2. 「New OAuth App」ボタンをクリック
+3. 以下の情報を入力：
+   - **Application name**: `Team29 Skill Tree (Development)` (任意の名前)
+   - **Homepage URL**: `http://localhost:3000`
+   - **Application description**: (任意)
+   - **Authorization callback URL**: `http://localhost:8000/api/v1/auth/github/callback`
+
+4. 「Register application」ボタンをクリック
+
+### 2. Client IDとClient Secretの取得
+
+1. 作成したOAuth Appのページで、**Client ID**が表示されます（コピーしておく）
+2. 「Generate a new client secret」ボタンをクリック
+3. 表示された**Client Secret**をコピー（⚠️ このページを離れると二度と表示されません）
+
+### 3. 環境変数の設定
+
+`backend/.env` ファイルを編集し、以下の値を設定します：
+
+```dotenv
+# GitHub OAuth (本番設定)
+GITHUB_CLIENT_ID=<先ほどコピーしたClient ID>
+GITHUB_CLIENT_SECRET=<先ほどコピーしたClient Secret>
+```
+
+**例**:
+
+```dotenv
+GITHUB_CLIENT_ID=Iv1.a1b2c3d4e5f6g7h8
+GITHUB_CLIENT_SECRET=1234567890abcdef1234567890abcdef12345678
+```
+
+### 4. 動作確認
+
+1. バックエンドサーバーを再起動：
+
+   ```bash
+   cd backend
+   poetry run uvicorn app.main:app --reload
+   ```
+
+2. フロントエンドサーバーを起動（別ターミナル）：
+
+   ```bash
+   cd frontend
+   npm run dev
+   ```
+
+3. ブラウザで `http://localhost:3000/login` にアクセス
+
+4. 「🚀 GitHub でログイン（推奨）」ボタンをクリック
+
+5. GitHubの認可ページが表示されたら成功です
+
+6. 「Authorize」をクリックすると、ダッシュボードにリダイレクトされます
+
+## トラブルシューティング
+
+### エラー: "GitHub OAuth は設定されていません"
+
+- `.env` ファイルの `GITHUB_CLIENT_ID` と `GITHUB_CLIENT_SECRET` が正しく設定されているか確認
+- バックエンドサーバーを再起動
+
+### エラー: "Invalid or expired state parameter"
+
+- CoWorks: `Authorization callback URL` が正しく設定されているか確認
+- `http://localhost:8000/api/v1/auth/github/callback` であることを確認
+
+### エラー: "The redirect_uri MUST match the registered callback URL"
+
+- GitHub OAuth Appの設定で、**Authorization callback URL** が `http://localhost:8000/api/v1/auth/github/callback` であることを確認
+- URLの末尾にスラッシュ `/` がないことを確認
+
+## 本番環境への展開
+
+本番環境では、以下のURLで新しいOAuth Appを作成してください：
+
+- **Homepage URL**: `https://your-production-domain.com`
+- **Authorization callback URL**: `https://your-api-domain.com/api/v1/auth/github/callback`
+
+本番用の `GITHUB_CLIENT_ID` と `GITHUB_CLIENT_SECRET` を本番サーバーの環境変数に設定します。
+
+## セキュリティ上の注意事項
+
+⚠️ **Client Secret は絶対に Git にコミットしないでください**
+
+- `.env` ファイルは `.gitignore` に含まれています
+- 本番環境では環境変数またはシークレット管理サービス（AWS Secrets Manager, GitHub Secrets等）を使用してください
+- Client Secret が漏洩した場合は、すぐにGitHub OAuth Appの設定から「Regenerate secret」を実行してください

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,10 +1,15 @@
+"use client";
+
 /**
  * Dashboard Page
- * ダッシュボード機能のメインページ
+ * ダッシュボード機能のメインページ（認証必須）
  */
 
-import { DashboardContainer } from '@/features/dashboard/components/DashboardContainer';
+import { withAuth } from "@/lib/auth/withAuth";
+import { DashboardContainer } from "@/features/dashboard/components/DashboardContainer";
 
-export default function DashboardPage() {
-  return <DashboardContainer userId="user-123" />;
+function DashboardPage() {
+  return <DashboardContainer />;
 }
+
+export default withAuth(DashboardPage);

--- a/frontend/src/app/exercises/page.tsx
+++ b/frontend/src/app/exercises/page.tsx
@@ -1,16 +1,19 @@
-'use client';
+"use client";
 
 /**
- * Exercise Menu Page
+ * Exercise Menu Page（認証必須）
  */
 
-import React from 'react';
-import { ExerciseMenu } from '@/features/exercise/components/ExerciseMenu';
+import React from "react";
+import { withAuth } from "@/lib/auth/withAuth";
+import { ExerciseMenu } from "@/features/exercise/components/ExerciseMenu";
 
-export default function ExercisePage() {
+function ExercisePage() {
   return (
     <div className="h-full w-full">
       <ExerciseMenu />
     </div>
   );
 }
+
+export default withAuth(ExercisePage);

--- a/frontend/src/app/grades/page.tsx
+++ b/frontend/src/app/grades/page.tsx
@@ -1,17 +1,20 @@
-'use client';
+"use client";
 
 /**
  * Grade Page
- * 成績を表示するページ
+ * 成績を表示するページ（認証必須）
  */
 
-import React from 'react';
-import { GradesContainer } from '@/features/grades/components/GradesContainer';
+import React from "react";
+import { withAuth } from "@/lib/auth/withAuth";
+import { GradesContainer } from "@/features/grades/components/GradesContainer";
 
-export default function GradePage() {
+function GradePage() {
   return (
     <div className="h-full w-full">
       <GradesContainer />
     </div>
   );
 }
+
+export default withAuth(GradePage);

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -50,15 +50,22 @@ export default function LoginPage() {
   ];
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-[#97C88C] p-4">
-      <div className="w-full max-w-md rounded-lg border-4 border-[#2C5F2D] bg-[#F5F5DC] p-8 shadow-[8px_8px_0_0_#2C5F2D]">
-        <h1 className="mb-6 text-center font-mono text-3xl font-bold tracking-widest text-[#2C5F2D]">
-          ログイン
-        </h1>
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-[#97C88C] via-[#A8D5A1] to-[#8BC880] p-4">
+      <div className="w-full max-w-md rounded-lg border-4 border-[#2C5F2D] bg-[#F5F5DC] p-8 shadow-[8px_8px_0_0_#2C5F2D] animate-[slideUp_0.3s_ease-out]">
+        {/* Header with Icon */}
+        <div className="mb-6 text-center">
+          <div className="mb-4 inline-flex items-center justify-center w-16 h-16 rounded-full bg-[#2C5F2D] text-3xl shadow-[4px_4px_0_0_#1F4521]">
+            🌳
+          </div>
+          <h1 className="font-mono text-3xl font-bold tracking-widest text-[#2C5F2D]">
+            SKILL TREE
+          </h1>
+          <p className="mt-2 text-sm text-gray-600">あなたの成長を可視化する</p>
+        </div>
 
         {error && (
-          <div className="mb-4 rounded border-2 border-red-600 bg-red-100 p-3 text-sm text-red-800">
-            {error}
+          <div className="mb-4 rounded border-2 border-red-600 bg-red-100 p-3 text-sm text-red-800 shadow-[2px_2px_0_0_rgba(220,38,38,0.3)] animate-[shake_0.3s]">
+            ⚠️ {error}
           </div>
         )}
 
@@ -67,12 +74,18 @@ export default function LoginPage() {
           <button
             type="button"
             onClick={handleGitHubLogin}
-            className="w-full rounded border-2 border-[#2C5F2D] bg-[#2C5F2D] p-4 font-mono font-bold tracking-widest text-white transition-colors hover:bg-[#1F4521]"
+            disabled={loading}
+            className="group relative w-full overflow-hidden rounded border-2 border-[#2C5F2D] bg-[#2C5F2D] p-4 font-mono font-bold tracking-widest text-white shadow-[4px_4px_0_0_#1F4521] transition-all hover:translate-x-[2px] hover:translate-y-[2px] hover:shadow-[2px_2px_0_0_#1F4521] active:translate-x-[4px] active:translate-y-[4px] active:shadow-none disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            🚀 GitHub でログイン（推奨）
+            <span className="relative z-10 flex items-center justify-center gap-2">
+              🚀 GitHub でログイン（推奨）
+            </span>
+            <div className="absolute inset-0 -translate-x-full bg-gradient-to-r from-transparent via-white/20 to-transparent group-hover:translate-x-full transition-transform duration-700" />
           </button>
-          <p className="mt-2 text-center text-xs text-gray-600">
-            あなたのGitHubリポジトリを分析してスキルツリーを自動生成
+          <p className="mt-3 text-center text-xs text-gray-600 leading-relaxed">
+            💡 GitHubリポジトリを分析して
+            <br />
+            パーソナライズされたスキルツリーを自動生成
           </p>
         </div>
 
@@ -128,13 +141,18 @@ export default function LoginPage() {
           <button
             type="submit"
             disabled={loading}
-            className="w-full rounded border-2 border-[#2C5F2D] bg-white p-3 font-mono font-bold tracking-widest text-[#2C5F2D] transition-colors hover:bg-gray-100 disabled:opacity-50"
+            className="w-full rounded border-2 border-[#2C5F2D] bg-white p-3 font-mono font-bold tracking-widest text-[#2C5F2D] shadow-[2px_2px_0_0_#2C5F2D] transition-all hover:translate-x-px hover:translate-y-px hover:shadow-[1px_1px_0_0_#2C5F2D] active:translate-x-0.5 active:translate-y-0.5 active:shadow-none disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {loading
-              ? "処理中..."
-              : isRegister
-                ? "登録してログイン"
-                : "ID/パスワードでログイン"}
+            {loading ? (
+              <span className="flex items-center justify-center gap-2">
+                <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-[#2C5F2D] border-t-transparent" />
+                処理中...
+              </span>
+            ) : isRegister ? (
+              "登録してログイン"
+            ) : (
+              "ID/パスワードでログイン"
+            )}
           </button>
         </form>
 
@@ -142,7 +160,7 @@ export default function LoginPage() {
           <button
             type="button"
             onClick={() => setIsRegister(!isRegister)}
-            className="font-mono text-sm text-[#2C5F2D] underline hover:text-[#1F4521]"
+            className="font-mono text-sm text-[#2C5F2D] underline hover:text-[#1F4521] transition-colors"
           >
             {isRegister
               ? "既にアカウントをお持ちの方はこちら"
@@ -150,25 +168,75 @@ export default function LoginPage() {
           </button>
         </div>
 
-        {/* テストユーザー情報 */}
-        <div className="mt-8 rounded border-2 border-[#2C5F2D] bg-white p-4">
-          <h2 className="mb-2 font-mono text-sm font-bold text-[#2C5F2D]">
-            テストユーザー（パスワード: testpass123）
-          </h2>
-          <ul className="space-y-1 text-xs">
-            {testUsers.map((user) => (
-              <li key={user.username} className="font-mono text-gray-700">
-                <span className="font-bold">{user.username}</span>
-                <br />
-                <span className="text-gray-600">{user.info}</span>
-              </li>
-            ))}
-          </ul>
-          <p className="mt-2 text-xs text-gray-500">
-            ※ テストユーザーは手動設定されたGitHubユーザー名を使用
-          </p>
-        </div>
+        {/* テストユーザー情報（折りたたみ可能） */}
+        <details className="mt-8 group">
+          <summary className="cursor-pointer rounded border-2 border-[#2C5F2D] bg-white p-3 font-mono text-sm font-bold text-[#2C5F2D] hover:bg-gray-50 transition-colors list-none flex items-center justify-between">
+            <span>🔧 テストユーザー情報</span>
+            <span className="transform transition-transform group-open:rotate-180">
+              ▼
+            </span>
+          </summary>
+          <div className="mt-2 rounded border-2 border-[#2C5F2D] bg-white p-4 animate-[slideDown_0.2s_ease-out]">
+            <p className="mb-2 font-mono text-xs text-gray-600">
+              パスワード:{" "}
+              <code className="bg-gray-100 px-2 py-1 rounded">testpass123</code>
+            </p>
+            <ul className="space-y-2 text-xs">
+              {testUsers.map((user) => (
+                <li
+                  key={user.username}
+                  className="font-mono text-gray-700 border-l-2 border-[#2C5F2D] pl-2"
+                >
+                  <span className="font-bold text-[#2C5F2D]">
+                    {user.username}
+                  </span>
+                  <br />
+                  <span className="text-gray-600">{user.info}</span>
+                </li>
+              ))}
+            </ul>
+            <p className="mt-3 text-xs text-gray-500 italic">
+              ※ テストユーザーは手動設定されたGitHubユーザー名を使用
+            </p>
+          </div>
+        </details>
       </div>
+
+      {/* CSS Animations */}
+      <style jsx>{`
+        @keyframes slideUp {
+          from {
+            opacity: 0;
+            transform: translateY(20px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+        @keyframes shake {
+          0%,
+          100% {
+            transform: translateX(0);
+          }
+          25% {
+            transform: translateX(-5px);
+          }
+          75% {
+            transform: translateX(5px);
+          }
+        }
+        @keyframes slideDown {
+          from {
+            opacity: 0;
+            transform: translateY(-10px);
+          }
+          to {
+            opacity: 1;
+            transform: translateY(0);
+          }
+        }
+      `}</style>
     </div>
   );
 }

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -39,16 +39,6 @@ export default function LoginPage() {
     window.location.href = `${apiBaseUrl}/api/v1/auth/github/login`;
   };
 
-  // テストユーザー情報
-  const testUsers = [
-    { username: "test_beginner", info: "初心者 (rank=2, GitHub: beginner123)" },
-    {
-      username: "test_intermediate",
-      info: "中級者 (rank=5, GitHub: Inlet-back)",
-    },
-    { username: "test_advanced", info: "上級者 (rank=8, GitHub: torvalds)" },
-  ];
-
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-[#97C88C] via-[#A8D5A1] to-[#8BC880] p-4">
       <div className="w-full max-w-md rounded-lg border-4 border-[#2C5F2D] bg-[#F5F5DC] p-8 shadow-[8px_8px_0_0_#2C5F2D] animate-[slideUp_0.3s_ease-out]">
@@ -167,39 +157,6 @@ export default function LoginPage() {
               : "新規登録はこちら"}
           </button>
         </div>
-
-        {/* テストユーザー情報（折りたたみ可能） */}
-        <details className="mt-8 group">
-          <summary className="cursor-pointer rounded border-2 border-[#2C5F2D] bg-white p-3 font-mono text-sm font-bold text-[#2C5F2D] hover:bg-gray-50 transition-colors list-none flex items-center justify-between">
-            <span>🔧 テストユーザー情報</span>
-            <span className="transform transition-transform group-open:rotate-180">
-              ▼
-            </span>
-          </summary>
-          <div className="mt-2 rounded border-2 border-[#2C5F2D] bg-white p-4 animate-[slideDown_0.2s_ease-out]">
-            <p className="mb-2 font-mono text-xs text-gray-600">
-              パスワード:{" "}
-              <code className="bg-gray-100 px-2 py-1 rounded">testpass123</code>
-            </p>
-            <ul className="space-y-2 text-xs">
-              {testUsers.map((user) => (
-                <li
-                  key={user.username}
-                  className="font-mono text-gray-700 border-l-2 border-[#2C5F2D] pl-2"
-                >
-                  <span className="font-bold text-[#2C5F2D]">
-                    {user.username}
-                  </span>
-                  <br />
-                  <span className="text-gray-600">{user.info}</span>
-                </li>
-              ))}
-            </ul>
-            <p className="mt-3 text-xs text-gray-500 italic">
-              ※ テストユーザーは手動設定されたGitHubユーザー名を使用
-            </p>
-          </div>
-        </details>
       </div>
 
       {/* CSS Animations */}
@@ -224,16 +181,6 @@ export default function LoginPage() {
           }
           75% {
             transform: translateX(5px);
-          }
-        }
-        @keyframes slideDown {
-          from {
-            opacity: 0;
-            transform: translateY(-10px);
-          }
-          to {
-            opacity: 1;
-            transform: translateY(0);
           }
         }
       `}</style>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,33 +1,31 @@
-import Image from "next/image";
-import Link from "next/link";
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { isAuthenticated } from "@/lib/auth/client";
 
 export default function Home() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      const authed = await isAuthenticated();
+      if (authed) {
+        router.replace("/dashboard");
+      } else {
+        router.replace("/login");
+      }
+    };
+    checkAuth();
+  }, [router]);
+
+  // リダイレクト中はローディング表示
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={100}
-          height={20}
-          priority
-        />
-        <div className="flex flex-col items-center gap-6 text-center sm:items-start sm:text-left">
-          <h1 className="max-w-xs text-3xl font-semibold leading-10 tracking-tight text-black dark:text-zinc-50">
-            スキルツリー学習プラットフォーム
-          </h1>
-          <p className="max-w-md text-lg leading-8 text-zinc-600 dark:text-zinc-400">
-            GitHub連携でパーソナライズされたスキルツリーを自動生成
-          </p>
-          <Link
-            href="/login"
-            className="rounded-full bg-foreground px-8 py-3 text-background transition-colors hover:bg-[#383838] dark:hover:bg-[#ccc]"
-          >
-            ログイン / 新規登録
-          </Link>
-        </div>
-      </main>
+    <div className="flex min-h-screen items-center justify-center bg-[#FDFEF0]">
+      <div className="text-center">
+        <div className="mb-4 inline-flex h-12 w-12 animate-spin rounded-full border-4 border-gray-300 border-t-[#559C71]" />
+        <p className="text-[#559C71] tracking-widest font-mono">LOADING...</p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/skills/page.tsx
+++ b/frontend/src/app/skills/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { withAuth } from "@/lib/auth/withAuth";
 import { SkillTreeCanvas } from "../../features/skill-tree/components/SkillTreeCanvas";
 import { SkillNodePanel } from "../../features/skill-tree/components/SkillNodePanel";
 import { RankBar } from "../../features/skill-tree/components/RankBar";
@@ -8,7 +9,7 @@ import { SkillLegend } from "../../features/skill-tree/components/SkillLegend";
 import { ZoomControls } from "../../features/skill-tree/components/ZoomControls";
 import type { SkillNode } from "../../features/skill-tree/types/data";
 
-export default function SkillTreePage() {
+function SkillTreePage() {
   const [selectedNode, setSelectedNode] = useState<SkillNode | null>(null);
   const [zoomAction, setZoomAction] = useState<{
     type: string;
@@ -72,3 +73,5 @@ export default function SkillTreePage() {
     </div>
   );
 }
+
+export default withAuth(SkillTreePage);

--- a/frontend/src/features/dashboard/components/DashboardContainer.tsx
+++ b/frontend/src/features/dashboard/components/DashboardContainer.tsx
@@ -37,13 +37,7 @@ const SkillTreeCanvas = dynamic(
   },
 );
 
-interface DashboardContainerProps {
-  userId?: string;
-}
-
-export function DashboardContainer({
-  userId = "default-user",
-}: DashboardContainerProps) {
+export function DashboardContainer() {
   // カテゴリ選択状態
   const [category, setCategory] = useState<string>("web");
 
@@ -81,7 +75,7 @@ export function DashboardContainer({
 
         // ユーザー基本情報とスキルツリーを並行取得
         const [statusData, treeData] = await Promise.all([
-          fetchUserDashboard(userId), // バッジ、ランク等（既存のmock API）
+          fetchUserDashboard("me"), // バッジ、ランク等（認証済みユーザー）
           fetchSkillTree(category), // スキルツリー（バックエンドAPI、認証済みユーザー）
         ]);
 
@@ -106,7 +100,7 @@ export function DashboardContainer({
     };
 
     loadDashboard();
-  }, [userId, category]);
+  }, [category]);
 
   if (loading) {
     return (

--- a/frontend/src/lib/auth/client.ts
+++ b/frontend/src/lib/auth/client.ts
@@ -1,0 +1,47 @@
+/**
+ * クライアントサイド認証ユーティリティ
+ * Cookie ベース認証（httpOnly Cookie）のため、認証状態は /users/me エンドポイントで確認
+ */
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+/**
+ * 認証状態確認
+ * @returns ログイン済みかどうか
+ */
+export async function isAuthenticated(): Promise<boolean> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/v1/users/me`, {
+      credentials: "include",
+      cache: "no-store",
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 現在のユーザー情報取得
+ * @returns ユーザー情報、未ログインの場合はnull
+ */
+export async function getCurrentUser(): Promise<{
+  id: number;
+  username: string;
+  level: number;
+  exp: number;
+  rank: number;
+} | null> {
+  try {
+    const response = await fetch(`${API_BASE_URL}/api/v1/users/me`, {
+      credentials: "include",
+      cache: "no-store",
+    });
+    if (!response.ok) {
+      return null;
+    }
+    return await response.json();
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/lib/auth/withAuth.tsx
+++ b/frontend/src/lib/auth/withAuth.tsx
@@ -1,0 +1,44 @@
+/**
+ * 認証ガードコンポーネント
+ * ログインしていない場合は /login にリダイレクト
+ */
+
+"use client";
+
+import { useEffect, useState, ComponentType } from "react";
+import { useRouter } from "next/navigation";
+import { isAuthenticated } from "@/lib/auth/client";
+
+export function withAuth<P extends object>(Component: ComponentType<P>) {
+  return function AuthGuardedComponent(props: P) {
+    const router = useRouter();
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+      const checkAuth = async () => {
+        const authed = await isAuthenticated();
+        if (!authed) {
+          router.replace("/login");
+        } else {
+          setLoading(false);
+        }
+      };
+      checkAuth();
+    }, [router]);
+
+    if (loading) {
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-[#FDFEF0]">
+          <div className="text-center">
+            <div className="mb-4 inline-flex h-12 w-12 animate-spin rounded-full border-4 border-gray-300 border-t-[#559C71]" />
+            <p className="text-[#559C71] tracking-widest font-mono">
+              LOADING...
+            </p>
+          </div>
+        </div>
+      );
+    }
+
+    return <Component {...props} />;
+  };
+}


### PR DESCRIPTION
**Issue**: #71

## 実装の概要

GitHub OAuthを使った認証機能を実装し、認証後にユーザーのGitHubリポジトリを分析してパーソナライズされたスキルツリーを自動生成する機能を統合しました。また、全ての保護されたページに認証ガードを実装し、未ログインユーザーを自動的にログイン画面へリダイレクトする仕組みを構築しました。

### 主な変更内容

#### 1. GitHub OAuth認証フローの統合
- OAuth callback時にUser + OAuthAccount + Profile を同一トランザクションで作成
- 既存ユーザーでもProfile未作成の場合は自動補完（マイグレーション対策）
- GitHubのログイン名を `github_username` として自動設定

#### 2. ログイン画面の改善
- グラデーション背景、アイコン（🌳）、アニメーション効果を追加
- GitHubログインボタンにシャインエフェクトを実装
- ローディング状態の視覚化（スピナー）
- テストユーザー情報セクションを削除（本番運用対応）

#### 3. ルート認証ガードの実装
- ルートページ（/）で認証状態に応じた自動リダイレクト
  - ログイン済み: `/dashboard` へリダイレクト
  - 未ログイン: `/login` へリダイレクト
- 認証チェックユーティリティ追加（`lib/auth/client.ts`）
- 認証ガードHOC追加（`lib/auth/withAuth.tsx`）
- 保護対象ページに適用: `/dashboard`, `/skills`, `/grades`, `/exercises`

#### 4. スキルツリーAPI改善
- `/users/me/skill-trees` に `category` クエリパラメータを追加
- カテゴリでフィルタリング可能に

#### 5. ドキュメント整備
- `docs/GITHUB_OAUTH_SETUP.md`: GitHub OAuth Appセットアップ手順
- `.github/decisions/IMPLEMENTATION_ISSUE_71.md`: 実装詳細とトラブルシューティング

## 🔧 技術的な意思決定とトレードオフ (最重要)

### 採用したアプローチ

#### 1. トランザクション管理
- **手法**: User/OAuthAccount/Profile を同一トランザクション（`commit=False` + 一括 `commit()`）で作成
- **メリット**:
  - アトミック性を保証し、ゾンビレコード（一部だけが保存される状態）を防止
  - データベース整合性を維持
- **デメリット/リスク**:
  - トランザクションが長くなり、ロック時間が増加する可能性
  - Profile作成に失敗すると全体がロールバックされる

#### 2. httpOnly Cookie認証
- **手法**: JWT を httpOnly Cookie に格納（`Authorization` ヘッダーは非推奨）
- **メリット**:
  - XSS攻撃からトークンを保護（JavaScriptからアクセス不可）
  - CSRF対策（SameSite=Lax）
  - フロントエンドでのトークン管理が不要
- **デメリット/リスク**:
  - クロスドメイン対応が複雑化
  - サーバーサイドでのCookie管理が必要

#### 3. クライアントサイド認証ガード
- **手法**: HOC（Higher-Order Component）パターンでページを保護
- **メリット**:
  - 再利用可能で一貫した認証チェック
  - コード重複を回避
  - ローディング状態の統一管理
- **デメリット/リスク**:
  - 初回レンダリング時に一瞬未認証状態が見える可能性（UX影響）
  - `/users/me` API呼び出しのオーバーヘッド

### 却下したアプローチ（代替案）

#### 1. Next.js Middleware での認証チェック
- **手法**: `middleware.ts` でサーバーサイド認証チェック
- **却下理由**:
  - httpOnly Cookie の読み取りが Edge Runtime で複雑
  - デプロイ環境（Vercel Edge等）への依存が増加
  - クライアントサイドでの柔軟性が低下

#### 2. Profile を別APIで作成
- **手法**: OAuth callback後、フロントエンドから `/users/me/profile` を呼び出し
- **却下理由**:
  - ユーザー体験の断絶（認証成功後に追加ステップが必要）
  - レースコンディション（Profile作成前にスキルツリーAPIが呼ばれる可能性）
  - エラーハンドリングの複雑化

## 🧪 テスト戦略と範囲

### 追加したテストケース

- [x] 正常系: GitHub OAuth認証フロー全体（既存テスト: `tests/test_api/test_auth.py`）
- [x] 正常系: スキルツリー生成とGitHub分析（既存テスト: `tests/test_services/test_skill_tree_service.py`）
- [ ] 異常系: Profile作成失敗時のロールバック確認
- [ ] 異常系: 認証ガードによる未ログインユーザーのリダイレクト
- [ ] **テストしていないこと**:
  - クライアントサイド認証ガードのタイミング（初回レンダリング時のフラッシュ）
  - 複数タブでの同時ログイン/ログアウト
  - GitHub OAuthのレート制限（403エラー）時の挙動
  - httpOnly Cookieのセキュリティ属性（Secure, SameSite）の実環境検証

## セキュリティに関する自己評価

- [x] 機密情報のハードコードはないか
  - GitHub Client ID/Secret は環境変数（`.env`）で管理
  - JWT秘密鍵は環境変数
- [x] 入力値の検証（バリデーション）は行っているか
  - username: 1〜72文字制限（ADR 017）
  - password: 1〜128文字制限（PBKDF2 DoS対策）
  - OAuth state パラメータのHMAC検証
- [x] 既知の脆弱性パターンへの対策は考慮したか
  - CSRF対策: HMAC署名付きstate + Cookie バインディング
  - XSS対策: httpOnly Cookie
  - SQLインジェクション対策: SQLAlchemy ORM使用
  - トークン盗取防止: JWT を URL パラメータに含めない

## レビュワー（人間）への申し送り事項

### セットアップが必要です
実際に動作確認するには以下が必要です：

1. **GitHub OAuth Appの作成**
   - 詳細は `docs/GITHUB_OAUTH_SETUP.md` を参照
   - Homepage URL: `http://localhost:3000`
   - Callback URL: `http://localhost:8000/api/v1/auth/github/callback`

2. **環境変数の設定（`backend/.env`）**
   ```dotenv
   GITHUB_CLIENT_ID=<あなたのClient ID>
   GITHUB_CLIENT_SECRET=<あなたのClient Secret>
   JWT_SECRET_KEY=<ランダム文字列>
   ENCRYPTION_KEY=<Fernetキー>