### PR TITLE
fix(auth): 異なるドメイン間でのCookie送信を有効化

### DIFF
--- a/backend/app/api/endpoints/auth.py
+++ b/backend/app/api/endpoints/auth.py
@@ -78,7 +78,7 @@ def set_auth_cookie(response: Response, token: str) -> None:
 
     - httpOnly: JS からアクセス不可 → XSS によるトークン盗取を防止
     - Secure: HTTPS 経由のみ送信（開発環境では localhost のため False でも可）
-    - SameSite=Lax: CSRF 対策（外部サイトからの POST リクエストでは送信しない）
+    - SameSite=None: 異なるドメイン間（Vercel ↔ Render）でCookie送信
     """
     is_https = urlparse(settings.FRONTEND_URL).scheme == "https"
     response.set_cookie(
@@ -86,7 +86,7 @@ def set_auth_cookie(response: Response, token: str) -> None:
         value=token,
         httponly=True,
         secure=is_https,
-        samesite="lax",
+        samesite="none" if is_https else "lax",
         max_age=settings.JWT_EXPIRE_HOURS * 3600,
         path="/",
     )
@@ -176,7 +176,7 @@ def github_login() -> RedirectResponse:
         value=state,
         httponly=True,
         secure=is_https,
-        samesite="lax",
+        samesite="none" if is_https else "lax",
         max_age=600,  # 10分（HMAC ウィンドウと同期）
         path="/",
     )


### PR DESCRIPTION
## 概要
Render（バックエンド）とVercel（フロントエンド）間でCookieが送信されず、GitHub OAuth認証後に401エラーが発生していた問題を修正。

## 問題
- OAuth callbackは成功するが、`/api/v1/users/me`で401 Unauthorized
- 原因: `SameSite=Lax`のため、異なるドメイン間でCookieが送信されない
- Render（`team29-backend.onrender.com`）とVercel（`*.vercel.app`）は異なるドメイン

## 変更内容
- `SameSite=None; Secure` に変更（HTTPS環境のみ）
- 開発環境（localhost）は`SameSite=Lax`を維持
- 対象Cookie:
  - `oauth_state`: OAuth CSRF対策用
  - `access_token`: JWT認証トークン

## セキュリティ考慮
- `Secure`フラグでHTTPS必須化
- `HttpOnly`フラグでXSS対策を維持
- `SameSite=None`は本番環境（HTTPS）のみ適用

## テスト
- [ ] ローカルで`SameSite=Lax`が適用されることを確認
- [ ] 本番環境（Render）で`SameSite=None; Secure`が適用されることを確認
- [ ] GitHub OAuth認証が成功すること
- [ ] `/api/v1/users/me`で認証情報が取得できること

## 影響範囲
- `backend/app/api/endpoints/auth.py`のみ
- Cookie設定のみの変更で、ロジックに影響なし

## デプロイ後の確認事項
- Render Logsで401エラーが解消されること
- フロントエンドでログイン→ダッシュボード遷移が成功すること