### PR TITLE
feat: #116 /gradesページのバッジ表示を/dashboardデザインに統一

### DIFF
--- a/frontend/src/features/grades/api/mock.ts
+++ b/frontend/src/features/grades/api/mock.ts
@@ -18,12 +18,73 @@ export const getGradeStats = async (): Promise<GradeStats> => {
 export const getBadges = async (): Promise<Badge[]> => {
   // TODO: Replace with actual API call
   return [
-    { id: '1', name: 'Master', icon: '🏆', type: 'trophy', earnedAt: '2025-01-01' },
-    { id: '2', name: 'Gold', icon: '🥇', type: 'gold', earnedAt: '2025-01-02' },
-    { id: '3', name: 'Silver', icon: '🥈', type: 'silver', earnedAt: '2025-01-03' },
-    { id: '4', name: 'Silver', icon: '🥈', type: 'silver', earnedAt: '2025-01-04' },
-    { id: '5', name: 'Bronze', icon: '🥉', type: 'bronze', earnedAt: '2025-01-05' },
-    { id: '6', name: 'Bronze', icon: '🥉', type: 'bronze', earnedAt: '2025-01-06' },
-    { id: '7', name: 'Bronze', icon: '🥉', type: 'bronze', earnedAt: '2025-01-07' },
+    { 
+      id: '1', 
+      name: 'Master Trophy', 
+      type: 'trophy', 
+      image: '/images/badges/Trophy.png',
+      sortOrder: 1,
+      earnedAt: '2025-01-01' 
+    },
+    { 
+      id: '5', 
+      name: 'Design Seed', 
+      type: 'rank', 
+      image: '/images/ranks/rank_tree_0.png',
+      category: 'design',
+      rankLevel: 0,
+      sortOrder: 2,
+      earnedAt: '2025-01-05' 
+    },
+    { 
+      id: '2', 
+      name: 'AI Sprout', 
+      type: 'rank', 
+      image: '/images/ranks/rank_tree_1.png',
+      category: 'ai',
+      rankLevel: 1,
+      sortOrder: 3,
+      earnedAt: '2025-01-02' 
+    },
+    { 
+      id: '3', 
+      name: 'Web Sprout', 
+      type: 'rank', 
+      image: '/images/ranks/rank_tree_1.png',
+      category: 'web',
+      rankLevel: 1,
+      sortOrder: 3,
+      earnedAt: '2025-01-03' 
+    },
+    { 
+      id: '4', 
+      name: 'Security Giant Tree', 
+      type: 'rank', 
+      image: '/images/ranks/rank_tree_3.png',
+      category: 'security',
+      rankLevel: 3,
+      sortOrder: 4,
+      earnedAt: '2025-01-04' 
+    },
+    { 
+      id: '7', 
+      name: 'Web Giant Tree', 
+      type: 'rank', 
+      image: '/images/ranks/rank_tree_3.png',
+      category: 'web',
+      rankLevel: 3,
+      sortOrder: 4,
+      earnedAt: '2025-01-07' 
+    },
+    { 
+      id: '6', 
+      name: 'Infra Grove', 
+      type: 'rank', 
+      image: '/images/ranks/rank_tree_5.png',
+      category: 'infra',
+      rankLevel: 5,
+      sortOrder: 5,
+      earnedAt: '2025-01-06' 
+    },
   ];
 };

--- a/frontend/src/features/grades/components/BadgeList.tsx
+++ b/frontend/src/features/grades/components/BadgeList.tsx
@@ -8,25 +8,23 @@ interface BadgeListProps {
   badges: Badge[];
 }
 
-// バッジタイプに応じた画像マッピング関数
-const getBadgeImage = (badge: Badge) => {
-  // まずtypeで判別
-  if (badge.type === 'trophy') return '/images/badges/Trophy.png';
-  if (badge.type === 'gold') return '/images/badges/AI_basic.png';
-  if (badge.type === 'silver') return '/images/badges/Web_base.png';
-  if (badge.type === 'bronze') return '/images/badges/Seed.png';
-  
-  // IDや名前でも判別（後方互換性）
-  if (badge.id.includes('web')) return '/images/badges/Web_base.png';
-  if (badge.id.includes('ai')) return '/images/badges/AI_basic.png';
-  if (badge.name.includes('Seed')) return '/images/badges/Seed.png';
-  if (badge.name.includes('Trophy') || badge.id.includes('trophy')) return '/images/badges/Trophy.png';
-  
-  // デフォルト
-  return '/images/badges/Trophy.png';
+// カテゴリ色定義
+const CATEGORY_COLORS: Record<string, string> = {
+  web: "#55aaff",
+  ai: "#e8b849",
+  security: "#e85555",
+  infra: "#55cc55",
+  design: "#cc66dd",
 };
 
 export const BadgeList: React.FC<BadgeListProps> = ({ badges }) => {
+  // ソート: トロフィー → 初級 → 中級 → 上級
+  const sortedBadges = [...badges].sort((a, b) => {
+    if (a.sortOrder !== b.sortOrder) {
+      return a.sortOrder - b.sortOrder;
+    }
+    return parseInt(a.id) - parseInt(b.id);
+  });
   return (
     <div className="mx-auto w-full max-w-5xl px-4">
       <div className="mb-4 flex items-center gap-4 pl-2">
@@ -53,8 +51,8 @@ export const BadgeList: React.FC<BadgeListProps> = ({ badges }) => {
         {/* バッジ一覧を横スクロール表示 */}
         {badges.length > 0 ? (
           <div className="flex min-w-max gap-6 items-end pb-4">
-            {badges.map((badge, index) => {
-              const isTrophy = badge.name.includes('Trophy') || badge.id.includes('trophy');
+            {sortedBadges.map((badge, index) => {
+              const isTrophy = badge.type === 'trophy';
               const sizeClass = isTrophy ? 'h-80 w-80' : 'h-60 w-60';
               const animationDelay = index * 0.2;
               
@@ -63,20 +61,62 @@ export const BadgeList: React.FC<BadgeListProps> = ({ badges }) => {
                   key={badge.id}
                   className="flex flex-col items-center gap-2 group"
                 >
-                  <span className="text-xl font-bold text-[#1a4023] opacity-0 group-hover:opacity-100 group-hover:animate-bounce transition-opacity">▼</span>
+                  <span className="text-xl font-bold text-[#2C5F2D] opacity-0 group-hover:opacity-100 group-hover:animate-bounce transition-opacity">
+                    ▼
+                  </span>
                   <div 
-                    className={`relative ${sizeClass} filter drop-shadow-[4px_4px_0_rgba(26,64,35,0.2)]`}
+                    className={`relative ${sizeClass} filter drop-shadow-[4px_4px_0_rgba(0,0,0,0.2)]`}
                     style={{
                       animation: 'float 2s steps(2) infinite',
                       animationDelay: `${animationDelay}s`,
                     }}
                   >
-                    <Image
-                      src={getBadgeImage(badge)}
-                      alt={badge.name}
-                      fill
-                      className="object-contain"
-                    />
+                    {/* 光の粒エフェクト（ランクバッジのみ） */}
+                    {!isTrophy && badge.category && (
+                      <>
+                        {[...Array(16)].map((_, i) => {
+                          const sparkleColor = CATEGORY_COLORS[badge.category!];
+                          // 不規則な遅延とポジション
+                          const delays = [
+                            0, 0.3, 0.7, 1.1, 0.5, 0.9, 1.3, 0.2, 0.8, 1.0, 0.4,
+                            1.2, 0.6, 1.4, 0.1, 1.5,
+                          ];
+                          const positions = [
+                            5, 15, 25, 35, 45, 55, 65, 75, 10, 20, 30, 40, 50, 60,
+                            70, 80,
+                          ];
+                          const delay = delays[i];
+                          const leftPosition = positions[i];
+
+                          return (
+                            <div
+                              key={i}
+                              className="absolute w-6 h-6 rounded-full"
+                              style={{
+                                backgroundColor: sparkleColor,
+                                left: `${leftPosition}%`,
+                                bottom: 0,
+                                opacity: 0.7,
+                                boxShadow: `0 0 10px ${sparkleColor}`,
+                                animation: "sparkle-rise 3s ease-in-out infinite",
+                                animationDelay: `${delay}s`,
+                                zIndex: 1,
+                              }}
+                            />
+                          );
+                        })}
+                      </>
+                    )}
+
+                    {/* バッジ画像 */}
+                    <div className="relative w-full h-full" style={{ zIndex: 2 }}>
+                      <Image
+                        src={badge.image}
+                        alt={badge.name}
+                        fill
+                        className="object-contain"
+                      />
+                    </div>
                   </div>
                   <span className="mt-2 text-center text-sm font-medium text-[#1a4023]">
                     {badge.name}

--- a/frontend/src/features/grades/types/index.ts
+++ b/frontend/src/features/grades/types/index.ts
@@ -15,7 +15,10 @@ export interface GradeStats {
 export interface Badge {
   id: string;
   name: string;
-  icon: string;
-  type: 'trophy' | 'gold' | 'silver' | 'bronze';
+  type: 'trophy' | 'rank';
+  image: string;           // 画像パス
+  category?: 'web' | 'ai' | 'security' | 'infra' | 'design';
+  rankLevel?: number;      // 0-9
+  sortOrder: number;       // トロフィー=1, 初級=2, 中級=3, 上級=4
   earnedAt?: string;
 }


### PR DESCRIPTION
# PR: /gradesページのバッジ表示を/dashboardデザインに統一

**Issue**: #116

## 実装の概要

/gradesページのバッジ表示を、/dashboardページで実装されている新しいバッジデザイン形式に統一しました。ランク画像（`rank_tree_*.png`）とカテゴリ色の光の粒エフェクトを使用した視覚的に魅力的なUIに変更しています。

### 主な変更点

1. **Badge型定義の統一** ([types/index.ts](frontend/src/features/grades/types/index.ts))
   - `type: 'trophy' | 'rank'` に変更（旧: 'trophy' | 'gold' | 'silver' | 'bronze'）
   - `image`、`category`、`rankLevel`、`sortOrder` プロパティを追加

2. **BadgeListコンポーネントの更新** ([components/BadgeList.tsx](frontend/src/features/grades/components/BadgeList.tsx))
   - カテゴリ色定義を追加（web: blue, ai: gold, security: red, infra: green, design: purple）
   - ランクバッジに光の粒エフェクト（16個のパーティクルが下から上へ立ち昇る）を追加
   - `/dashboard`と同じアニメーション（float、sparkle-rise）を適用
   - バッジのソート順を実装（トロフィー→低ランク→高ランク）

3. **モックデータの更新** ([api/mock.ts](frontend/src/features/grades/api/mock.ts))
   - バッジ名を英語ランク名形式に変更（例: "AI Sprout", "Web Giant Tree", "Infra Grove"）
   - ランク画像パス（`/images/ranks/rank_tree_0.png` ~ `rank_tree_9.png`）を使用
   - sortOrderを調整（Trophy=1, Seed=2, Sprout=3, Giant Tree=4, Grove=5）

## 🔧 技術的な意思決定とトレードオフ (最重要)

### 採用したアプローチ

- **手法**: `/dashboard/components/AcquiredBadges.tsx` の実装をベースに、既存の `/grades/components/BadgeList.tsx` を全面的に書き換え
- **メリット**:
  - 2つのページ間でバッジUIの一貫性が確保される
  - 既に動作確認済みのコード（dashboard）を再利用するため、バグリスクが低い
  - 光の粒エフェクトにより、ユーザーのモチベーション向上が期待できる
  - カテゴリ別の色分けにより、バッジの種類が直感的に理解できる
- **デメリット/リスク**:
  - アニメーションが多いため、低スペック端末でパフォーマンスが低下する可能性
  - 16個のDOM要素（光の粒）が各バッジに追加されるため、多数のバッジがある場合にレンダリングコストが増加
  - グローバルCSS（`sparkle-rise`アニメーション）に依存しているため、CSS削除時に影響を受ける

### 却下したアプローチ（代替案）

- **手法1**: 既存のバッジ画像（Trophy.png, AI_basic.png等）を使い続ける
- **却下理由**: Issue要件が「/dashboardと同じデザイン」であり、新しいrank_tree画像を使用することが明示されているため
- **手法2**: 光の粒エフェクトを簡素化（8個に削減、またはCSS filter効果のみ）
- **却下理由**: /dashboardとの完全な統一を優先。パフォーマンス問題が実際に発生した場合に最適化を検討するべき

## 🧪 テスト戦略と範囲

### 追加したテストケース

- [ ] 正常系: 型定義がTypeScriptコンパイラでエラーなく通ることを確認（`get_errors`ツールで確認済み）
- [ ] 正常系: モックデータが新しいBadge型に適合していることを確認
- [ ] 正常系: バッジがsortOrder順にソートされることをロジックで保証
- [ ] **テストしていないこと**:
  - ブラウザ実機での光の粒アニメーション動作確認（開発サーバーで目視確認が必要）
  - 低スペック端末でのパフォーマンス測定
  - バッジが100個以上ある場合のスクロールパフォーマンス
  - カテゴリ色定義と実際のカテゴリ値の整合性（実際のAPIデータでの検証が必要）

## セキュリティに関する自己評価

- [x] 機密情報のハードコードはないか → ✅ なし（画像パスとカテゴリ色定義のみ）
- [x] 入力値の検証（バリデーション）は行っているか → ✅ TypeScriptの型システムで保証
- [x] 既知の脆弱性パターンへの対策は考慮したか → ✅ 外部入力なし、静的データのみ使用

## レビュワー（人間）への申し送り事項

- **動作確認**: `/grades` ページで以下を確認してください：
  1. バッジが「トロフィー → 低ランク → 高ランク」の順で左から表示される
  2. ランクバッジにカテゴリ色の光の粒が下から上へ立ち昇る
  3. バッジがホバー時に▼が表示される
  4. floatアニメーションが動作する（バッジが上下に揺れる）
- **既知の制限事項**:
  - グローバルCSSの `sparkle-rise` アニメーションは既に定義済みのため、追加作業なし
  - モックデータは仮のデータであり、実際のAPI連携後に調整が必要
- **次のステップ**:
  - 実際のAPIから取得するバッジデータが新しいBadge型に適合しているか確認
  - 必要に応じて、バックエンドのレスポンス形式を調整

---

Closes #116
